### PR TITLE
🐛 Fixed #2 - allows the use of the walrus operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 ARG ARCH=
-FROM ${ARCH}debian:buster-slim
+FROM ${ARCH}python:3.8
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y \
-    software-properties-common \
-    curl \
-    git \
-    python3 \
     python3-pip
 
 


### PR DESCRIPTION
Switched to Python 3.8 to allow the use of walrus operator as discussed in #2 .