### PR TITLE
🐛 Fixed docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   discord-fury:
-    build: src
+    build: .
     volumes:
       - "./data:/app/data:rw"
     environment:


### PR DESCRIPTION
Caused by legacy code, the Dockerfile was marked as being in src/