### PR TITLE
↗️ Improved compatibilty with newer python versions

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -16,6 +16,24 @@ on:
   push:
     branches: master
 jobs:
+  building-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: build the image for amd64
+        run: |
+          docker buildx build --push \
+            --tag "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":amd64-latest \
+            --platform linux/amd64 .
+
   building-arm64v8:
     runs-on: ubuntu-latest
     steps:
@@ -30,8 +48,9 @@ jobs:
 
       - name: build the image for arm64v8
         run: |
-          docker build -t "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm64v8-latest --build-arg ARCH=arm64v8/ -f Dockerfile . &&\
-          docker push "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm64v8-latest
+          docker buildx build --push \
+            --tag "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm64v8-latest \
+            --platform linux/arm64 .
 
   building-arm32v7:
     runs-on: ubuntu-latest
@@ -47,25 +66,9 @@ jobs:
 
       - name: build the image for arm32v7
         run: |
-          docker build -t "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm32v7-latest --build-arg ARCH=arm32v7/ -f Dockerfile . &&\
-          docker push "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm32v7-latest
-
-  building-amd64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: setup-docker
-        uses: docker-practice/actions-setup-docker@master
-
-      - name: checkout code
-        uses: actions/checkout@v2
-
-      - name: login to docker hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-          
-      - name: build the image for amd64
-        run: |
-          docker build -t "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":amd64-latest --build-arg ARCH=amd64/ -f Dockerfile . &&\
-          docker push "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":amd64-latest
+          docker buildx build --push \
+            --tag "${{ secrets.DOCKER_USERNAME }}"/"${{ secrets.DOCKER_REPOSITORY }}":arm32v7-latest \
+            --platform linux/arm/v7 .
 
   manifest-create:
     needs: [building-arm64v8, building-arm32v7, building-amd64]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH=
-FROM ${ARCH}debian:buster-slim
+FROM ${ARCH}python:3.8
+
 RUN apt-get update && apt-get -y upgrade && apt-get install -y \
-    python3 \
     python3-pip
 
 


### PR DESCRIPTION
At the moment, we are using a Debian base image for the docker container.
For this reason, we only can install python versions via apt, which are already in the Debian repositories.
We COULD compile newer python versions manually into our Debian based image, but this would lead into a bigger image size and a more complicated Dockerfile which would be harder to maintain.
We weren't able to switch to the Python base image before, since Docker build was't able to build it for ARM platforms.

This is why I suggest the following changes:

Using docker buildx -> Improved compatibilty of build process
Changing the base image to python:3.8 -> easier upgrade process with less overhead
I'm still building the 3 images in 3 jobs -> faster build process.
We could use "docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7", but I wouldn't recommend it for obvious performance reasons.

The build process was already tested within a test repository, everything should work first try (please don't quote me on that later :D).

Docker buildx is a quemu based experimental feature. But in my experience, it's working perfectly fine for over a year at this point.