### PR TITLE
:arrow_upper_right:  Added settings to enable the renaming of private voice channels

### DIFF
--- a/src/cogs/on_voice_update.py
+++ b/src/cogs/on_voice_update.py
@@ -185,9 +185,25 @@ class VoiceChannelCreator(commands.Cog):
 				v_overwrites = {} #None except it's a private channel
 				if ch_type == "priv": #giving member special perms when private channel
 					v_overwrites = {
-						member: discord.PermissionOverwrite(manage_permissions=True, manage_channels=True, connect=True), #give member connect and manage rights 
+						#give member connect and manage rights 
             			member.guild.default_role: discord.PermissionOverwrite(connect=False)
 					}
+
+				#checking if users should have rights to rename pub channel
+				#chanenls can't be synced anymore - need to set general role permissions
+				elif checker.get_edit_perms():
+					#checking for new custom-default role
+					def_role = checker.default_role()
+					if def_role is not None:
+						def_role = member.guild.get_role(def_role)
+					#taking standard default role
+					else:
+						def_role = member.guild.default_role
+					#give he default role default perms
+					#and creator rename rights
+					v_overwrites = after.channel.category.overwrites
+					v_overwrites[member] = discord.PermissionOverwrite(manage_channels=True,
+					 										connect=True)
 
 				#creating channels
 				v_channel = await member.guild.create_voice_channel(

--- a/src/cogs/on_voice_update.py
+++ b/src/cogs/on_voice_update.py
@@ -59,6 +59,20 @@ class EventCheck:
 		except IndexError:
 			return None
 
+	def get_edit_perms(self): #return 0 (False) by default
+		result = self.db.search_table(value="edit_channel", column="setting")
+		try:
+			return result[0].value_id
+		except IndexError:
+			return 0
+
+	def default_role(self): #returns None when no set
+		result = self.db.search_table(value="default_role", column="setting")
+		try:
+			return result[0].value_id
+		except IndexError:
+			return None
+
 	def del_entry(self, channel):
 		db = sqltils.DbConn(db_file, self.member.guild.id, "created_channels")
 		db.remove_line(channel, column="channel_id")

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -176,24 +176,53 @@ class Settings(commands.Cog):
 			await ctx.send(embed=emby)
 
 
-	@commands.command(name="set-archive", aliases=["sa"], help=f"Set an archive category for created text-channels and log channel.\n\
+
+
+	@commands.command(name="set", aliases=["sa"], help=f"Change various settings.\n\
+		`Options`:\n\
+		archive - needs category ID\n\
+		`log` - needs category ID\n\
+		`default-role` - needs role ID\n\
 		Usage: \
-		`{config.PREFIX}sa [archive | log] [category-id | channel-id]`.\n \
-		Please not that text-channels will only be archived when they contain at least one message, they'll be deleted otherwise. \n \
+		`{config.PREFIX}sa [`Option`] [needed argument]`.\n \
+		Please note that text-channels will only be archived when they contain at least one message, they'll be deleted otherwise. \n \
+		Also the `default-role` option comes with some disadvantages, e.g. new VCs aren't synced with their category\n\
 		This option is - also - admin only")
 	@commands.has_permissions(administrator=True) 
 	async def set_archive(self, ctx, setting: str, value: str):
 		#possible settings switch -returns same value but nothing if key isn't valid
 		settings = {
 			"archive": utils.get_chan(ctx.guild, value),
-			"log": utils.get_chan(ctx.guild, value)
+			"log": utils.get_chan(ctx.guild, value),
+			"default-role": utils.get_rid(ctx, [value])
 		}
 		#trying to get a corresponding channel / id
 		value = settings.get(setting)
 		#if value is "None" this means that there is no such setting or no such value for it
 		#checking if keyword mateches the entered channel type
 		# -> ensures that the process of getting a correct setting has worked
-		if value is not None and value.type == discord.ChannelType.text and setting == "log" \
+		
+		if setting == "default-role" and value is not None:
+			role = ctx.guild.get_role(value[0][0])
+			db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
+			
+			#if setting is already there old value needs to be deleted
+			if len(db.search_table(value="default_role", column="setting")) == 1: #there can only be one archive and log
+				db.remove_line('"default_role"', column="setting")	
+			
+			#editing db
+			entry = ("default_role", "value_name", role.id,\
+					time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL)				
+			db.write_server_table(entry)
+			
+			#sending reply
+			emby = utils.make_embed(color=discord.Color.green(),
+				name="Success",
+				value=f"Your new defaul role is: {role.mention}")
+			await ctx.send(embed=emby)
+
+		#set channels
+		elif value is not None and value.type == discord.ChannelType.text and setting == "log" \
 									or value.type == discord.ChannelType.category and setting == "archive":
 
 			#conneting to db - creating a new one if there is none yet


### PR DESCRIPTION
VCs can now be renamed by the creator of the channel when admins activate this feature in the settings.