### PR TITLE
🆕 Break out rooms

### DIFF
--- a/src/cogs/admin.py
+++ b/src/cogs/admin.py
@@ -1,213 +1,213 @@
-#built in
+# built in
 import time
 import os
 import re
 
-#pip
+# pip
 import discord
 from discord.ext import commands
 
-#own
+# own
 import data.config as config
 import utils
 
-#wrinting suggestsion in file
+
+# writing suggestion in file
 def write_log(ctx, file_name, content):
+    # checking if folder exists and creating if needed
+    server_dir = ctx.guild.id
+    if os.path.isdir('./data/%s' % server_dir):
+        None
+    else:
+        os.mkdir('./data/%s' % server_dir)
+        # writing current name of the guild as file
+        # preventing from trying to create an sub folder
+        open('./data/%s/%s.info' % (server_dir, str(ctx.guild).replace("/", "|")), "w").close()
 
-	#checking if folder exists and creating if needed
-	server_dir = ctx.guild.id
-	if os.path.isdir('./data/%s' %server_dir):
-		None
-	else:
-		os.mkdir('./data/%s' %server_dir)
-		#writing current name of the guild as file
-		#preventing from trying to create an sub folder
-		open('./data/%s/%s.info' %(server_dir, str(ctx.guild).replace("/", "|")),"w").close()
+    # checking if file exists and creating if needed
+    file_path = file_name
+    if os.path.isfile(file_path):
+        None
+    else:
+        open(file_path, "w").close()
 
-	#checking if file exists and creating if needed
-	file_path = file_name
-	if os.path.isfile(file_path):
-		None
-	else:
-		open(file_path, "w").close()
-
-	data = content
-	f = open(file_path, "a")
-	f.write(data)
-	f.close()
+    data = content
+    f = open(file_path, "a")
+    f.write(data)
+    f.close()
 
 
 class Admin(commands.Cog):
-	"""
-	This commands are for the server team, most require admin or owner permissions
-	"""
-	def __init__(self, bot):
-		self.bot = bot
+    """
+    This commands are for the server team, most require admin or owner permissions
+    """
 
-	#AIR
-	#ORION
-	
-	@commands.command(name="fetch-reactions", hidden=True)
-	@commands.has_permissions(administrator=True)
-	async def fetch_message(self, ctx):
-		"""
-		A butch, that fixes a problem with the reaction bot
-		It's disgusting and hardcoded but I'm gonna leave it here, cause I need it to fix an other bot
-		"""
-		if ctx.guild.id == 760421261649248296:
-			channel = ctx.guild.get_channel(760455084353650698)
-			message = await channel.fetch_message(760455425610350602)
-			users = await message.reactions[0].users().flatten()
-			role = ctx.guild.get_role(760434164146634752)
-			i = 0
-			for user in users:
-				member = ctx.guild.get_member(user.id)
-				if member == None:
-					pass
-				elif len(member.roles) == 1:
-					print(member)
-					await member.add_roles(role, reason="Reaction bot didn't work")
-					i += 1
-			await ctx.send(content=f"Done, added {i} new members to {role.name}")
+    def __init__(self, bot):
+        self.bot = bot
 
+    # AIR
+    # ORION
 
-	
-	@commands.command(name='backup-roles', aliases=["broles", "br"], help="Creates a backupfile with all roles members have\n"
-								"This can be executed by everyone with kick-permissions \n_Short term:_ `%sbroles`, `%sbr`"%(config.PREFIX, config.PREFIX))
-	@commands.has_permissions(kick_members=True) 
-	async def backup(self, ctx):#, member : discord.Member):
-		#await ctx.send(ctx.message.guild.members)
-		f_name = "backup_%s.csv" %time.strftime("%Y-%m-%d_%H-%M-%S")
-		file_name="data/%s/%s" %(ctx.message.guild.id, f_name)
-		restore_string = ""
-		#remove roles from members
-		for member in ctx.message.guild.members: #iterating trough all memebers
-			#going through roles of member
-			for role in member.roles:           #getting all roles of member
-				#print(role)
-				if role.id == member.guild.default_role.id:    #skipping if role is @everyone role
-					None
-				elif role.managed == True:      #skipping if role is managed, e.g. bot-role
-					None
-				else:                          #saving role
-					#string that conatins member-name,memberID,role,roleID, date
-					restore_string += "%s; %s; %s; %s\n" %(str(member).replace(";", ":"), member.id, str(role).replace(";", ":"), role.id)
+    @commands.command(name="fetch-reactions", hidden=True)
+    @commands.has_permissions(administrator=True)
+    async def fetch_message(self, ctx):
+        """
+        A butch, that fixes a problem with the reaction bot
+        It's disgusting and hardcoded but I'm gonna leave it here, cause I need it to fix an other bot
+        """
+        if ctx.guild.id == 760421261649248296:
+            channel = ctx.guild.get_channel(760455084353650698)
+            message = await channel.fetch_message(760455425610350602)
+            users = await message.reactions[0].users().flatten()
+            role = ctx.guild.get_role(760434164146634752)
+            i = 0
+            for user in users:
+                member = ctx.guild.get_member(user.id)
+                if member == None:
+                    pass
+                elif len(member.roles) == 1:
+                    print(member)
+                    await member.add_roles(role, reason="Reaction bot didn't work")
+                    i += 1
+            await ctx.send(content=f"Done, added {i} new members to {role.name}")
 
-		write_log(ctx, file_name, restore_string)
-		
-		emby = discord.Embed(title="", color=discord.Color.green())
-		emby.add_field(name="Backup created", value="**Please save the name of this file, you need it for restoring it**\n`%s`" %f_name)
-		await ctx.message.delete(delay=None)        #delete invoke message
-		await ctx.send(embed=emby)
-		
-		print()
-		print('Backup created by %s (%s)'%(ctx.message.author, ctx.message.author.id))
-		print()
-	
+    @commands.command(name='backup-roles', aliases=["broles", "br"],
+                      help="Creates a backupfile with all roles members have\n"
+                           "This can be executed by everyone with kick-permissions \n_Short term:_ `%sbroles`, `%sbr`" % (
+                                   config.PREFIX, config.PREFIX))
+    @commands.has_permissions(kick_members=True)
+    async def backup(self, ctx):  # , member : discord.Member):
+        # await ctx.send(ctx.message.guild.members)
+        f_name = "backup_%s.csv" % time.strftime("%Y-%m-%d_%H-%M-%S")
+        file_name = "data/%s/%s" % (ctx.message.guild.id, f_name)
+        restore_string = ""
+        # remove roles from members
+        for member in ctx.message.guild.members:  # iterating trough all members
+            # going through roles of member
+            for role in member.roles:  # getting all roles of member
+                # print(role)
+                if role.id == member.guild.default_role.id:  # skipping if role is @everyone role
+                    None
+                elif role.managed:  # skipping if role is managed, e.g. bot-role
+                    None
+                else:  # saving role
+                    # string that contains member-name,memberID,role,roleID, date
+                    restore_string += "%s; %s; %s; %s\n" % (
+                        str(member).replace(";", ":"), member.id, str(role).replace(";", ":"), role.id)
 
+        write_log(ctx, file_name, restore_string)
 
-	#Reverse BACKUP
-	#Precise Filename is needed as argument
-	@commands.command(name="restore", help="Restore a backup from file - Usage: `%srestore <file_name>`\nThe filename was given, when the backup was created"%config.PREFIX)
-	@commands.has_permissions(administrator=True) 
-	async def re_escalate(self, ctx, file_name: str):
-		try:
-			owner = config.OWNER
-			if ctx.message.author.id == owner: #check if owner
-				#reading and iteration trough file
-				f = open("data/%s/%s" %(ctx.message.guild.id, file_name), "r")
-				await ctx.message.delete(delay=None) #delete invoke message - if we reached that point the filename is right
-				#strrage for different types of errors
-				line_errors = ""
-				data_errors = ""
-				perm_erros = ""
-				for line in f:
-					line = line.split(";") #making list
-					#a rough check if the line has the right length, if not there might be a semicolon in the name - skipping
-					if len(line) > 4:
-						line_errors += str(line) + "\n"
-					
-					else:
-						#getting member and role
-						member = ctx.guild.get_member(int(line[1]))
-						member_status = True #has to stay true for further actions
-						if member == None:
-							member_status = False #setting it to false
-							data_errors += "Can't resolve member ID `%s`\n" %str(line[1].strip())
+        emby = discord.Embed(title="", color=discord.Color.green())
+        emby.add_field(name="Backup created",
+                       value="**Please save the name of this file, you need it for restoring it**\n`%s`" % f_name)
+        await ctx.message.delete(delay=None)  # delete invoke message
+        await ctx.send(embed=emby)
 
-						
-						role = ctx.guild.get_role(int(line[3]))
-						role_status = True
-						if role == None:
-							role_status = False
-							data_errors += "Can't resolve role ID `%s`\n" %str(line[3].strip())
+        print()
+        print('Backup created by %s (%s)' % (ctx.message.author, ctx.message.author.id))
+        print()
 
-						#adding role to member if gained information was valid
-						#going trough the roles a member has and checking if he has the needed role
-						#if he has not the role will be added
-						if role_status == True and member_status == True:
-							for r in member.roles:
-								if r.id == role.id:
-									break
-							else:
-								#check if bot can give this role from position
-								if role.position > ctx.guild.me.top_role.position:
-									perm_erros += "%s to %s\n" %(member.mention, role.mention)
-								else:
-									await member.add_roles(role, reason="Restored roles form backup")
-									print("Adding %s to %s" %(member.display_name, role.name))
+    # Reverse BACKUP
+    # Precise Filename is needed as argument
+    @commands.command(name="restore",
+                      help="Restore a backup from file - Usage: `%srestore <file_name>`\nThe filename was given, when the backup was created" % config.PREFIX)
+    @commands.has_permissions(administrator=True)
+    async def re_escalate(self, ctx, file_name: str):
+        try:
+            owner = config.OWNER
+            if ctx.message.author.id == owner:  # check if owner
+                # reading and iteration trough file
+                f = open("data/%s/%s" % (ctx.message.guild.id, file_name), "r")
+                await ctx.message.delete(
+                    delay=None)  # delete invoke message - if we reached that point the filename is right
+                # strrage for different types of errors
+                line_errors = ""
+                data_errors = ""
+                perm_erros = ""
+                for line in f:
+                    line = line.split(";")  # making list
+                    # a rough check if the line has the right length, if not there might be a semicolon in the name - skipping
+                    if len(line) > 4:
+                        line_errors += str(line) + "\n"
 
-				
+                    else:
+                        # getting member and role
+                        member = ctx.guild.get_member(int(line[1]))
+                        member_status = True  # has to stay true for further actions
+                        if member == None:
+                            member_status = False  # setting it to false
+                            data_errors += "Can't resolve member ID `%s`\n" % str(line[1].strip())
 
-				print()
-				print("Finished")
-				print()
-				emby = discord.Embed(title="Success", color=discord.Color.green())
-				#emby.add_field(name="Restored status from backup", value="")
-				emby.add_field(name="Line-Errors", value= "Problem with the following lines:\n\n" + line_errors)
-				emby.add_field(name="Data-Errors", value= "Role and User IDs that were not available:\n\n" + data_errors)
-				emby.add_field(name="Permission-Errors", value="Roles the bot can't give because they are too high:\n\n" + perm_erros)
-				await ctx.send(embed=emby)
+                        role = ctx.guild.get_role(int(line[3]))
+                        role_status = True
+                        if role == None:
+                            role_status = False
+                            data_errors += "Can't resolve role ID `%s`\n" % str(line[3].strip())
 
-		except:
-			await ctx.send(content="Error. Maybe the filename was wrong?")
+                        # adding role to member if gained information was valid
+                        # going trough the roles a member has and checking if he has the needed role
+                        # if he has not the role will be added
+                        if role_status == True and member_status == True:
+                            for r in member.roles:
+                                if r.id == role.id:
+                                    break
+                            else:
+                                # check if bot can give this role from position
+                                if role.position > ctx.guild.me.top_role.position:
+                                    perm_erros += "%s to %s\n" % (member.mention, role.mention)
+                                else:
+                                    await member.add_roles(role, reason="Restored roles form backup")
+                                    print("Adding %s to %s" % (member.display_name, role.name))
 
+                print()
+                print("Finished")
+                print()
+                emby = discord.Embed(title="Success", color=discord.Color.green())
+                # emby.add_field(name="Restored status from backup", value="")
+                emby.add_field(name="Line-Errors", value="Problem with the following lines:\n\n" + line_errors)
+                emby.add_field(name="Data-Errors", value="Role and User IDs that were not available:\n\n" + data_errors)
+                emby.add_field(name="Permission-Errors",
+                               value="Roles the bot can't give because they are too high:\n\n" + perm_erros)
+                await ctx.send(embed=emby)
 
+        except:
+            await ctx.send(content="Error. Maybe the filename was wrong?")
 
-	#ROLE ID
-	@commands.command(name="role-id", aliases=["roleid", "rid", "r-id"], help="Mention a role or just give its name to get the roles ID\n Aliases: `roleid`, `rid`, `r-id`")
-	@commands.has_permissions(kick_members=True)
-	async def roleid(self, ctx, *role_name: str):
-		try:
-			role, le = utils.get_rid(ctx, role_name) #getting IDs
-			if le == 1: #if only one ID returned
-				role = ctx.guild.get_role(role[0])
-				await ctx.send(content=role.id)
-			
-			else: #if more than one result - giving all possible roles
-				emby = discord.Embed(title="Multiple possible roles", color=discord.Color.blue())
-				possible_roles = ""
-				for r in role: #iterating trough roles
-					print(r)
-					r = ctx.guild.get_role(r)
-					i = 0
-					for members in r.members: #counting members
-						i += 1
-					possible_roles += "%s with %s members - ID: %s\n" %(r.mention, i, r.id)
+    # ROLE ID
+    @commands.command(name="role-id", aliases=["roleid", "rid", "r-id"],
+                      help="Mention a role or just give its name to get the roles ID\n Aliases: `roleid`, `rid`, `r-id`")
+    @commands.has_permissions(kick_members=True)
+    async def roleid(self, ctx, *role_name: str):
+        try:
+            role, le = utils.get_rid(ctx, role_name)  # getting IDs
+            if le == 1:  # if only one ID returned
+                role = ctx.guild.get_role(role[0])
+                await ctx.send(content=role.id)
 
-				emby.add_field(name="Which one do you mean?", value=possible_roles)
-				emby.set_footer(text="To get an easy copy-pasteable ID mention the role you mean")
-				await ctx.send(embed=emby)
+            else:  # if more than one result - giving all possible roles
+                emby = discord.Embed(title="Multiple possible roles", color=discord.Color.blue())
+                possible_roles = ""
+                for r in role:  # iterating trough roles
+                    print(r)
+                    r = ctx.guild.get_role(r)
+                    i = 0
+                    for members in r.members:  # counting members
+                        i += 1
+                    possible_roles += "%s with %s members - ID: %s\n" % (r.mention, i, r.id)
 
+                emby.add_field(name="Which one do you mean?", value=possible_roles)
+                emby.set_footer(text="To get an easy copy-pasteable ID mention the role you mean")
+                await ctx.send(embed=emby)
 
-		except:
-			emby = discord.Embed(title="", color=discord.Color.red())
-			emby.add_field(name="Something went wrong", value="Please check your given argument.\n"
-							"Note that name inputs are handled case-sensitive and spaces in names might cause trouble.\n"
-							"Syntax: `%smembers <@role | role id | role name>`"%config.PREFIX)
-			emby.set_footer(text="If you did everything right and this error keeps occuring, please contact the bot owner %s" %config.OWNER_NAME)
-			await ctx.send(embed = emby)
+        except:
+            emby = discord.Embed(title="", color=discord.Color.red())
+            emby.add_field(name="Something went wrong", value="Please check your given argument.\n"
+                                                              "Note that name inputs are handled case-sensitive and spaces in names might cause trouble.\n"
+                                                              "Syntax: `%smembers <@role | role id | role name>`" % config.PREFIX)
+            emby.set_footer(
+                text="If you did everything right and this error keeps occurring, please contact the bot owner %s" % config.OWNER_NAME)
+            await ctx.send(embed=emby)
 
 
 def setup(bot):
-	bot.add_cog(Admin(bot)) 
+    bot.add_cog(Admin(bot))

--- a/src/cogs/mod_commands.py
+++ b/src/cogs/mod_commands.py
@@ -1,0 +1,62 @@
+import random
+from typing import List
+
+import discord
+from discord.ext import commands
+
+import utils
+from cogs.on_voice_update import make_channel
+
+
+class Moderator(commands.Cog):
+    """
+    Here are commands that not any member can access but everyone with kick permissions (for now)
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name="break-out", aliases=["bro"])
+    @commands.has_permissions(kick_members=True)
+    async def break_out_rooms(self, ctx: discord.ext.commands.Context, *split: str):
+
+        if not ctx.author.voice:
+            await ctx.send(embed=utils.make_embed("You're not in a VoiceChannel", discord.Color.orange(),
+                                                  value="Please enter a Voice Channel and try again"))
+            return
+
+        # ensuring members var is given
+        try:
+            if int(split[0]) > 0:
+                split = int(split[0])
+
+            else:
+                await ctx.send(embed=utils.make_embed("Number must be greater than 0", discord.Color.orange(),
+                                                      value="Try again :wink:"))
+                return
+
+        except ValueError:
+            await ctx.send(embed=utils.make_embed("Wrong argument", discord.Color.orange(),
+                                                  value="Please enter the amount of members per channel"))
+            return
+
+        base_vc: discord.VoiceChannel = ctx.author.voice.channel
+
+        # channels_to_create = len(vc.members) // split
+        # TODO: Remove invoker from list
+        mv_channel = None
+        members: List[discord.Member] = base_vc.members.copy()
+        random.shuffle(members)
+        overwrites = base_vc.category.overwrites
+
+        for i in range(len(base_vc.members)):
+            if i % split == 0:
+                mv_channel, _ = await make_channel(ctx.author.voice, members[i], overwrites,
+                                                   vc_name=f"Breakout Room {i // split + 1}",
+                                                   tc_name=f"Breakout Room {i // split + 1}")
+
+            await members[i].move_to(mv_channel, reason="Moved to breakout room")
+
+
+def setup(bot):
+    bot.add_cog(Moderator(bot))

--- a/src/cogs/on_voice_update.py
+++ b/src/cogs/on_voice_update.py
@@ -1,13 +1,13 @@
-#built in
+# built in
 from typing import Union
 import random
 import time
 
-#pip
+# pip
 import discord
 from discord.ext import commands
 
-#own files
+# own files
 import data.config as config
 import sql_utils as sqltils
 import utils
@@ -17,256 +17,262 @@ db_file = config.DB_NAME
 
 
 class EventCheck:
-	"""
+    """
 	Responsible for DB access
 	has methods to check which actions need to be triggered
 	"""
-	def __init__(self, member, before, after):
-		self.member = member
-		self.before = before
-		self.after = after
-		self.db = sqltils.DbConn(db_file, self.member.guild.id, "setting")
 
-	def is_activate(self) -> Union[str, bool]:
-		#checks if joined channel is in the list of watched channels
-		#accessing db and searching for settings - building a dict
-		self.channel_dict = {obj.value_id: "pub"
-					for obj in self.db.search_table(value="pub-channel", column="setting")}
-		self.channel_dict.update({obj.value_id: "priv"
-					for obj in self.db.search_table(value="priv-channel", column="setting")})
+    def __init__(self, member, before, after):
+        self.member = member
+        self.before = before
+        self.after = after
+        self.db = sqltils.DbConn(db_file, self.member.guild.id, "setting")
 
-		try: #return keyword "pub" or "priv", if channel id in dict
-			return self.channel_dict[self.after.channel.id]
-		except KeyError as e: #if not in dict, returning none
-			return None
+    def is_activate(self) -> Union[str, bool]:
+        # checks if joined channel is in the list of watched channels
+        # accessing db and searching for settings - building a dict
+        self.channel_dict = {obj.value_id: "pub"
+                             for obj in self.db.search_table(value="pub-channel", column="setting")}
+        self.channel_dict.update({obj.value_id: "priv"
+                                  for obj in self.db.search_table(value="priv-channel", column="setting")})
 
-	def is_created_channel(self, channel: int) -> list:
-		#checks if joined channel is a custom created one - returns all results as objects
-		db = sqltils.DbConn(db_file, self.member.guild.id, "created_channels")
-		return db.search_table(value=channel, column="channel_id")
+        try:  # return keyword "pub" or "priv", if channel id in dict
+            return self.channel_dict[self.after.channel.id]
+        except KeyError as e:  # if not in dict, returning none
+            return None
 
-	def get_archive(self): #resturns channel object
-		result = self.db.search_table(value="archive", column="setting")
-		try:
-			return self.member.guild.get_channel(result[0].value_id)
-		except IndexError:
-			return None
+    def is_created_channel(self, channel: int) -> list:
+        # checks if joined channel is a custom created one - returns all results as objects
+        db = sqltils.DbConn(db_file, self.member.guild.id, "created_channels")
+        return db.search_table(value=channel, column="channel_id")
 
-	def get_log(self): #resturns channel object
-		result = self.db.search_table(value="log", column="setting")
-		try:
-			return self.member.guild.get_channel(result[0].value_id)
-		except IndexError:
-			return None
+    def get_archive(self):  # resturns channel object
+        result = self.db.search_table(value="archive", column="setting")
+        try:
+            return self.member.guild.get_channel(result[0].value_id)
+        except IndexError:
+            return None
 
-	def get_edit_perms(self): #return 0 (False) by default
-		result = self.db.search_table(value="edit_channel", column="setting")
-		try:
-			return result[0].value_id
-		except IndexError:
-			return 0
+    def get_log(self):  # resturns channel object
+        result = self.db.search_table(value="log", column="setting")
+        try:
+            return self.member.guild.get_channel(result[0].value_id)
+        except IndexError:
+            return None
 
-	def default_role(self): #returns None when no set
-		result = self.db.search_table(value="default_role", column="setting")
-		try:
-			return result[0].value_id
-		except IndexError:
-			return None
+    def get_edit_perms(self):  # return 0 (False) by default
+        result = self.db.search_table(value="edit_channel", column="setting")
+        try:
+            return result[0].value_id
+        except IndexError:
+            return 0
 
-	def del_entry(self, channel):
-		db = sqltils.DbConn(db_file, self.member.guild.id, "created_channels")
-		db.remove_line(channel, column="channel_id")
+    def default_role(self):  # returns None when no set
+        result = self.db.search_table(value="default_role", column="setting")
+        try:
+            return result[0].value_id
+        except IndexError:
+            return None
+
+    def del_entry(self, channel):
+        db = sqltils.DbConn(db_file, self.member.guild.id, "created_channels")
+        db.remove_line(channel, column="channel_id")
 
 
 channel_names = {"pub": [["╠{0}'s discussion", "{0}'s discussion"],
-					["╠{0}'s voice channel", "{0}'s text channel" ],
-					["╠{0}'s room", "{0}'s room"],
-					["╠{0}'s open talk", "{0}'s open talk"],
-					["╠{0}'s bar", "{0}'s bar"],
-					["╠{0}'s' public office", "{0}'s public office"]
-					],
+                         ["╠{0}'s voice channel", "{0}'s text channel"],
+                         ["╠{0}'s room", "{0}'s room"],
+                         ["╠{0}'s open talk", "{0}'s open talk"],
+                         ["╠{0}'s bar", "{0}'s bar"],
+                         ["╠{0}'s' public office", "{0}'s public office"]
+                         ],
 
-			"priv": [["╠{0}'s private discussion", "{0}'s private discussion"],
-					["╠{0}'s private fellowship", "{0}'s private fellowship"],
-					["╠{0}'s private room", "{0}'s private room"],
-					["╠{0}'s elite room", "{0}'s elite room"],
-					["╠{0}'s regular table", "{0}'s regular table"],
-					["╠{0}'s private haven", "{0}'s private haven"]
-				]
-				}
+                 "priv": [["╠{0}'s private discussion", "{0}'s private discussion"],
+                          ["╠{0}'s private fellowship", "{0}'s private fellowship"],
+                          ["╠{0}'s private room", "{0}'s private room"],
+                          ["╠{0}'s elite room", "{0}'s elite room"],
+                          ["╠{0}'s regular table", "{0}'s regular table"],
+                          ["╠{0}'s private haven", "{0}'s private haven"]
+                          ]
+                 }
 
 
 class VoiceChannelCreator(commands.Cog):
-	"""
+    """
 	Contains the setup-voice command and the listener itself
 	"""
-	@commands.command(name="setup-voice", help="Creates a voice category, \
+
+    @commands.command(name="setup-voice", help="Creates a voice category, \
 				including a public and a private creation channel.\
 				Those channels will contain no specified settings.\
 				Enter a role [id | mention] to add give this role the access permissions -\
 				everyone role will be disabled")
-	@commands.has_permissions(administrator=True)
-	async def setup_voice(self, ctx, role=None):	
-		await ctx.trigger_typing()
-		ov = {ctx.guild.default_role: discord.PermissionOverwrite(view_channel=True, connect=True, speak=True)}
-		
-		if role: #if there was a role as input - making custom overwrite
-			role, leng = utils.get_rid(ctx, [role])
-			role = ctx.guild.get_role(role[0])
-			print(role)
-			if role:
-				ov = {
-					ctx.guild.default_role: discord.PermissionOverwrite(view_channel=False, connect=False, speak=False),
-					role: discord.PermissiosnOverwrite(view_channel=True, connect=True, speak=True)
-				}
-			else:
-				await ctx.send(embed=utils.make_embed(value="Hey, the given id is invalid,\
-								I'm trying to create the channels but with the default settings.",\
-								name="No valid role", color=discord.Color.orange()))
-		#creating channels
-		cat = await ctx.guild.create_category_channel("Voice Channels", overwrites=ov, reason="Created voice setup")
-		await cat.edit(overwrites=ov, position=0) #move up didn't work in the creation
-		pub_ch = await ctx.guild.create_voice_channel("╔create-voice-channel", category=cat, reason="Created voice setup")
-		priv_ch = await ctx.guild.create_voice_channel("╠new-private-channel", category=cat, reason="Created voice setup")
-		db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
-		#checking if db has three entries for one of those settings
-		if len(db.search_table(value="pub-channel", column="setting")) < config.SET_LIMIT \
-		or len(db.search_table(value="priv-channel", column="setting")) < config.SET_LIMIT:
-			db.write_server_table(("pub-channel", "value_name", pub_ch.id, time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL))
-			db.write_server_table(("priv-channel", "value_name", priv_ch.id, time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL))
+    @commands.has_permissions(administrator=True)
+    async def setup_voice(self, ctx, role=None):
+        await ctx.trigger_typing()
+        ov = {ctx.guild.default_role: discord.PermissionOverwrite(view_channel=True, connect=True, speak=True)}
 
-			await ctx.send(embed=utils.make_embed(name="Sucessfully setup voice category",\
-						value="You're category is set, have fun!\n \
+        if role:  # if there was a role as input - making custom overwrite
+            role, leng = utils.get_rid(ctx, [role])
+            role = ctx.guild.get_role(role[0])
+            print(role)
+            if role:
+                ov = {
+                    ctx.guild.default_role: discord.PermissionOverwrite(view_channel=False, connect=False, speak=False),
+                    role: discord.PermissiosnOverwrite(view_channel=True, connect=True, speak=True)
+                }
+            else:
+                await ctx.send(embed=utils.make_embed(value="Hey, the given id is invalid,\
+								I'm trying to create the channels but with the default settings.", \
+                                                      name="No valid role", color=discord.Color.orange()))
+        # creating channels
+        cat = await ctx.guild.create_category_channel("Voice Channels", overwrites=ov, reason="Created voice setup")
+        await cat.edit(overwrites=ov, position=0)  # move up didn't work in the creation
+        pub_ch = await ctx.guild.create_voice_channel("╔create-voice-channel", category=cat,
+                                                      reason="Created voice setup")
+        priv_ch = await ctx.guild.create_voice_channel("╠new-private-channel", category=cat,
+                                                       reason="Created voice setup")
+        db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
+        # checking if db has three entries for one of those settings
+        if len(db.search_table(value="pub-channel", column="setting")) < config.SET_LIMIT \
+                or len(db.search_table(value="priv-channel", column="setting")) < config.SET_LIMIT:
+            db.write_server_table(
+                ("pub-channel", "value_name", pub_ch.id, time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL))
+            db.write_server_table(
+                ("priv-channel", "value_name", priv_ch.id, time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL))
+
+            await ctx.send(embed=utils.make_embed(name="Sucessfully setup voice category", \
+                                                  value="You're category is set, have fun!\n \
 						Oh, yeah - you can change the channel names how ever you like :)", color=discord.Color.green()))
-		
-		else: #if channel max was reached
-			await ctx.send(embed=utils.make_embed(name="Too many channels!",
-							value=f"Hey, you can't make me watch more than {config.SET_LIMIT} channels per creation type.\n\
+
+        else:  # if channel max was reached
+            await ctx.send(embed=utils.make_embed(name="Too many channels!",
+                                                  value=f"Hey, you can't make me watch more than {config.SET_LIMIT} channels per creation type.\n\
 							If you wanna change the channels I watch use \
 							`{config.PREFIX}ds [channel-id]` to remove a channel from your settings\n \
 							The channels were created but aren't watched, have a look at `{config.PREFIX}help settings`\
 							to add them manually after you removed other watched channels from the settings"))
 
-##Codename: PANTHEON
-	"""
+    ##Codename: PANTHEON
+    """
 	A function that creates custom voice channels if triggered
 	 - Creates a dedicated voice-channel
 	 - Creates a private linked text-channel
 	 - Members will be added and removed to text-channel
 	 - There is an option for a customizable /private voice-channel
 	"""
-	@commands.Cog.listener()
-	async def on_voice_state_update(self, member, before, after):
-		
-		def make_overwrite(members: list) -> dict: #creates the overwrites dict for the text-channel
-			return {m:discord.PermissionOverwrite(view_channel=True) for m in members}
 
-		def update_text_channel(cchannel):
-			#function that makes the dict overwrites for text channels
-			v_channel = member.guild.get_channel(cchannel[0].channel)
-			t_channel = member.guild.get_channel(cchannel[0].linked_channel)
-			overwrites = {member.guild.default_role: discord.PermissionOverwrite(view_channel=False)}
-			overwrites.update(make_overwrite(v_channel.members))
-			return t_channel, overwrites
-			
-		#object that performs checks which cases are true
-		checker = EventCheck(member, before, after) 
-		l_channel = checker.get_log() #log channel
+    @commands.Cog.listener()
+    async def on_voice_state_update(self, member, before, after):
 
-		if after.channel: #check if person is in channel
-			#check if creating is triggered creation type or none
-			ch_type = checker.is_activate() 
-			#if joined channel was created - returns list with objects of all positive results
-			cchannel = checker.is_created_channel(after.channel.id) 
-			#creating channel
-			if ch_type:
-				channel_name = random.choice(channel_names[ch_type]) #getting channel name
+        def make_overwrite(members: list) -> dict:  # creates the overwrites dict for the text-channel
+            return {m: discord.PermissionOverwrite(view_channel=True) for m in members}
 
-				v_overwrites = {} #None except it's a private channel
-				if ch_type == "priv": #giving member special perms when private channel
-					v_overwrites = {
-						#give member connect and manage rights 
-            			member.guild.default_role: discord.PermissionOverwrite(connect=False)
-					}
+        def update_text_channel(cchannel):
+            # function that makes the dict overwrites for text channels
+            v_channel = member.guild.get_channel(cchannel[0].channel)
+            t_channel = member.guild.get_channel(cchannel[0].linked_channel)
+            overwrites = {member.guild.default_role: discord.PermissionOverwrite(view_channel=False)}
+            overwrites.update(make_overwrite(v_channel.members))
+            return t_channel, overwrites
 
-				#checking if users should have rights to rename pub channel
-				#chanenls can't be synced anymore - need to set general role permissions
-				elif checker.get_edit_perms():
-					#checking for new custom-default role
-					def_role = checker.default_role()
-					if def_role is not None:
-						def_role = member.guild.get_role(def_role)
-					#taking standard default role
-					else:
-						def_role = member.guild.default_role
-					#give he default role default perms
-					#and creator rename rights
-					v_overwrites = after.channel.category.overwrites
-					v_overwrites[member] = discord.PermissionOverwrite(manage_channels=True,
-					 										connect=True)
+        # object that performs checks which cases are true
+        checker = EventCheck(member, before, after)
+        l_channel = checker.get_log()  # log channel
 
-				#creating channels
-				v_channel = await member.guild.create_voice_channel(
-								channel_name[0].format(member.display_name),
-								category=after.channel.category, overwrites=v_overwrites)
-				t_channel = await member.guild.create_text_channel(
-								channel_name[1].format(member.display_name),
-								category=after.channel.category,
-								overwrites={member: discord.PermissionOverwrite(view_channel=True),
-								member.guild.default_role: discord.PermissionOverwrite(view_channel=False)})
+        if after.channel:  # check if person is in channel
+            # check if creating is triggered creation type or none
+            ch_type = checker.is_activate()
+            # if joined channel was created - returns list with objects of all positive results
+            cchannel = checker.is_created_channel(after.channel.id)
+            # creating channel
+            if ch_type:
+                channel_name = random.choice(channel_names[ch_type])  # getting channel name
 
-				#writing new channels to db
-				db = sqltils.DbConn(db_file, member.guild.id, "created_channels")
-				db.write_server_table((ch_type, v_channel.id, t_channel.id,
-										time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL))
-				
-				if l_channel:
-					await l_channel.send(embed=utils.make_embed(name="Created Voicechannel",
-							value=f"{member.mention} created `{v_channel}` with {t_channel.mention}",
-							color=discord.Color.green()))
+                v_overwrites = {}  # None except it's a private channel
+                if ch_type == "priv":  # giving member special perms when private channel
+                    v_overwrites = {
+                        # give member connect and manage rights
+                        member.guild.default_role: discord.PermissionOverwrite(connect=False)
+                    }
 
-				#moving creator to his channel
-				await member.move_to(v_channel, reason=f'{member} issued creation')
+                # checking if users should have rights to rename pub channel
+                # chanenls can't be synced anymore - need to set general role permissions
+                elif checker.get_edit_perms():
+                    # checking for new custom-default role
+                    def_role = checker.default_role()
+                    if def_role is not None:
+                        def_role = member.guild.get_role(def_role)
+                    # taking standard default role
+                    else:
+                        def_role = member.guild.default_role
+                    # give he default role default perms
+                    # and creator rename rights
+                    v_overwrites = after.channel.category.overwrites
+                    v_overwrites[member] = discord.PermissionOverwrite(manage_channels=True,
+                                                                       connect=True)
 
-			elif cchannel: #adding member to textchannel, if member joined created channel 
-				t_channel, overwrites = update_text_channel(cchannel)
-				await t_channel.edit(overwrites=overwrites)
+                # creating channels
+                v_channel = await member.guild.create_voice_channel(
+                    channel_name[0].format(member.display_name),
+                    category=after.channel.category, overwrites=v_overwrites)
+                t_channel = await member.guild.create_text_channel(
+                    channel_name[1].format(member.display_name),
+                    category=after.channel.category,
+                    overwrites={member: discord.PermissionOverwrite(view_channel=True),
+                                member.guild.default_role: discord.PermissionOverwrite(view_channel=False)})
 
+                # writing new channels to db
+                db = sqltils.DbConn(db_file, member.guild.id, "created_channels")
+                db.write_server_table((ch_type, v_channel.id, t_channel.id,
+                                       time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL))
 
-		if before.channel: #if member leaves channel
-			cchannel = checker.is_created_channel(before.channel.id)
+                if l_channel:
+                    await l_channel.send(embed=utils.make_embed(name="Created Voicechannel",
+                                                                value=f"{member.mention} created `{v_channel}` with {t_channel.mention}",
+                                                                color=discord.Color.green()))
 
-			if before.channel.members == [] and cchannel: #if channel is empty -> delete
-				v_channel = member.guild.get_channel(cchannel[0].channel)
-				t_channel = member.guild.get_channel(cchannel[0].linked_channel)
-				#check if archive is given and if channel contains messages to archive
-				try: #trying to archive category - throws an error when category is full 
-					if (checker.get_archive()) and t_channel.last_message != None:
-						archive = checker.get_archive()
-						await t_channel.edit(category=archive, reason="Voice is empty, this channel not")
-					
-					else: #empty channel
-						await t_channel.delete(reason="Channel is empty and not needed anymore")
-					
-					checker.del_entry(v_channel.id) #removing entry from db
-					await v_channel.delete(reason="Channel is empty")
-					if l_channel: #logging
-						await l_channel.send(embed=utils.make_embed(name="Created Voicechannel",
-								value=f"{member.mention} created `{v_channel}` with {t_channel.mention}",
-								color=discord.Color.green()))
-				
-				#happens when if archive is full
-				except discord.errors.HTTPException:
-					await l_channel.send(embed=utils.make_embed(name="ERROR", color=discord.Color.red(),
-								value=f"This error probably means that the archive category is full, please check it and \n \
+                # moving creator to his channel
+                await member.move_to(v_channel, reason=f'{member} issued creation')
+
+            elif cchannel:  # adding member to textchannel, if member joined created channel
+                t_channel, overwrites = update_text_channel(cchannel)
+                await t_channel.edit(overwrites=overwrites)
+
+        if before.channel:  # if member leaves channel
+            cchannel = checker.is_created_channel(before.channel.id)
+
+            if before.channel.members == [] and cchannel:  # if channel is empty -> delete
+                v_channel = member.guild.get_channel(cchannel[0].channel)
+                t_channel = member.guild.get_channel(cchannel[0].linked_channel)
+                # check if archive is given and if channel contains messages to archive
+                try:  # trying to archive category - throws an error when category is full
+                    if (checker.get_archive()) and t_channel.last_message != None:
+                        archive = checker.get_archive()
+                        await t_channel.edit(category=archive, reason="Voice is empty, this channel not")
+
+                    else:  # empty channel
+                        await t_channel.delete(reason="Channel is empty and not needed anymore")
+
+                    checker.del_entry(v_channel.id)  # removing entry from db
+                    await v_channel.delete(reason="Channel is empty")
+                    if l_channel:  # logging
+                        await l_channel.send(embed=utils.make_embed(name="Created Voicechannel",
+                                                                    value=f"{member.mention} created `{v_channel}` with {t_channel.mention}",
+                                                                    color=discord.Color.green()))
+
+                # happens when if archive is full
+                except discord.errors.HTTPException:
+                    await l_channel.send(embed=utils.make_embed(name="ERROR", color=discord.Color.red(),
+                                                                value=f"This error probably means that the archive category is full, please check it and \n \
 										set a new one or delete older channels - Nothing was deleted"))
-					
 
-			elif cchannel: #removing member from textchannel when left
-				t_channel = member.guild.get_channel(cchannel[0].linked_channel)
-				t_channel, overwrites = update_text_channel(cchannel)
-				await t_channel.edit(overwrites=overwrites)
+
+            elif cchannel:  # removing member from textchannel when left
+                t_channel = member.guild.get_channel(cchannel[0].linked_channel)
+                t_channel, overwrites = update_text_channel(cchannel)
+                await t_channel.edit(overwrites=overwrites)
 
 
 def setup(bot):
-	bot.add_cog(VoiceChannelCreator(bot))
+    bot.add_cog(VoiceChannelCreator(bot))

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -1,13 +1,13 @@
-#built in
+# built in
 import os
 import time
 import sql_utils as sqltils
 
-#pip
+# pip
 import discord
 from discord.ext import commands
 
-#own files
+# own files
 import utils
 import data.config as config
 
@@ -16,244 +16,235 @@ db_file = config.DB_NAME
 
 
 class Settings(commands.Cog):
-	"""
-	Set / cutsomize default Settings (beta)
-	"""
-	def __init__(self, bot):
-		self.bot = bot
+    """
+    Set / cutsomize default Settings (beta)
+    """
 
+    def __init__(self, bot):
+        self.bot = bot
 
-	@commands.command(name="set-voice-channel", aliases=["set-voice", "svc"], help=f"This command \
-		allows you to set a custom 'create-voice-channel' channel name\n \
-		Usage: \
-		`{config.PREFIX}svc [pub-channel | priv-channel] [channel-id]` - alias: `{config.PREFIX}svc`.\n \
-		`pub-channel` and `priv-channel` are the options of channels that are created when joining the creation-channel,\
-		enter one of those options. \n \
-		This option is - obviously - admin only")
-	@commands.has_permissions(administrator=True) 
-	async def set_voice(self, ctx, setting: str, value: str):
-		#possible settings switch -returns same value but nothing if key isn't valid
-		settings = {
-			"pub-channel": utils.get_chan(ctx.guild, value),
-			"priv-channel": utils.get_chan(ctx.guild, value)
-		}
-		#trying to get a corresponding channel / id
-		value = settings.get(setting)
-		#if value is "None" this means that there is no such setting or no such value for it
-		# -> ensures that the process of getting a correct setting has worked
-		if value is not None and value.type == discord.ChannelType.voice:
+    @commands.command(name="set-voice-channel", aliases=["set-voice", "svc"], help=f"This command \
+        allows you to set a custom 'create-voice-channel' channel name\n \
+        Usage: \
+        `{config.PREFIX}svc [pub-channel | priv-channel] [channel-id]` - alias: `{config.PREFIX}svc`.\n \
+        `pub-channel` and `priv-channel` are the options of channels that are created when joining the creation-channel,\
+        enter one of those options. \n \
+        This option is - obviously - admin only")
+    @commands.has_permissions(administrator=True)
+    async def set_voice(self, ctx, setting: str, value: str):
+        # possible settings switch -returns same value but nothing if key isn't valid
+        settings = {
+            "pub-channel": utils.get_chan(ctx.guild, value),
+            "priv-channel": utils.get_chan(ctx.guild, value)
+        }
+        # trying to get a corresponding channel / id
+        value = settings.get(setting)
+        # if value is "None" this means that there is no such setting or no such value for it
+        # -> ensures that the process of getting a correct setting has worked
+        if value is not None and value.type == discord.ChannelType.voice:
 
-			#conneting to db - creating a new one if there is none yet
-			db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
+            # conneting to db - creating a new one if there is none yet
+            db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
 
-			#Settings won't be storred if max watched channels are reached
-			#-> searching for amaount of matching entries
-			if len(db.search_table(value=setting, column="setting")) >= config.SET_LIMIT:
+            # Settings won't be storred if max watched channels are reached
+            # -> searching for amaount of matching entries
+            if len(db.search_table(value=setting, column="setting")) >= config.SET_LIMIT:
 
-				text = f"Hey, you can't make me watch more than {config.SET_LIMIT} channels for this setting\n \
-						If you wanna change the channels I watch use `{config.PREFIX}ds [channel-id]` to remove a channel from your settings"				
-				emby = utils.make_embed(color=discord.Color.orange(), name= "Too many entries", value=text)
-				await ctx.send(embed=emby)
-			
-			#writing entry to db - the way things sould go
-			else:
-				entry = (setting, "value_name", value.id, time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL)
-				db.write_server_table(entry)
+                text = f"Hey, you can't make me watch more than {config.SET_LIMIT} channels for this setting\n \
+                        If you wanna change the channels I watch use `{config.PREFIX}ds [channel-id]` to remove a channel from your settings"
+                emby = utils.make_embed(color=discord.Color.orange(), name="Too many entries", value=text)
+                await ctx.send(embed=emby)
 
-				emby = utils.make_embed(color=discord.Color.green(), name= "Success", value="Setting saved")
-				await ctx.send(embed=emby)
+            # writing entry to db - the way things sould go
+            else:
+                entry = (setting, "value_name", value.id, time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL)
+                db.write_server_table(entry)
 
-		#when false inputs were given
-		else:
-			value = ("Please ensure that you've entered a valid setting \
-					and channel-id for that setting.")
-			emby = utils.make_embed(color=discord.Color.orange(), name="Can't get setting", value=value)
-			await ctx.send(embed=emby)
+                emby = utils.make_embed(color=discord.Color.green(), name="Success", value="Setting saved")
+                await ctx.send(embed=emby)
 
+        # when false inputs were given
+        else:
+            value = ("Please ensure that you've entered a valid setting \
+                    and channel-id for that setting.")
+            emby = utils.make_embed(color=discord.Color.orange(), name="Can't get setting", value=value)
+            await ctx.send(embed=emby)
 
+    @commands.command(name="get-settings", aliases=["gs"], help=f"\
+                                Get a list of all watched 'create-voice' channels - alias: `{config.PREFIX}gvc`")
+    @commands.has_permissions(administrator=True)
+    async def get_settings(self, ctx):
+        """
+        prints set channels
+        """
+        db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
+        results = db.read_server_table()  # gets a list ob entry objects
 
-	@commands.command(name="get-settings", aliases=["gs"], help=f"\
-								Get a list of all watched 'create-voice' channels - alias: `{config.PREFIX}gvc`")
-	@commands.has_permissions(administrator=True) 
-	async def get_settings(self, ctx):
-		"""
-		prints set channels
-		"""
-		db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
-		results = db.read_server_table() #gets a list ob entry objects
-		
-		pub = "__Public Channels:__\n"
-		priv = "__Private Channels:___\n"
-		log = "__Log Channel__\n"
-		archive = "__Archive Category__\n"
-		for i in range(len(results)): #building strings
-			if results[i].setting == "pub-channel":
-				pub += f"`{ctx.guild.get_channel(results[i].value_id)}` with ID `{results[i].value_id}`\n"
-				
-			elif results[i].setting == "priv-channel":
-				priv += f"`{ctx.guild.get_channel(results[i].value_id)}` with ID `{results[i].value_id}`\n"
+        pub = "__Public Channels:__\n"
+        priv = "__Private Channels:___\n"
+        log = "__Log Channel__\n"
+        archive = "__Archive Category__\n"
+        for i in range(len(results)):  # building strings
+            if results[i].setting == "pub-channel":
+                pub += f"`{ctx.guild.get_channel(results[i].value_id)}` with ID `{results[i].value_id}`\n"
 
-			elif results[i].setting == "log":
-				log += f"`{ctx.guild.get_channel(results[i].value_id)}` with ID `{results[i].value_id}`\n"
+            elif results[i].setting == "priv-channel":
+                priv += f"`{ctx.guild.get_channel(results[i].value_id)}` with ID `{results[i].value_id}`\n"
 
-			elif results[i].setting == "archive":
-				archive += f"`{ctx.guild.get_channel(results[i].value_id)}` with ID `{results[i].value_id}`\n"
+            elif results[i].setting == "log":
+                log += f"`{ctx.guild.get_channel(results[i].value_id)}` with ID `{results[i].value_id}`\n"
 
+            elif results[i].setting == "archive":
+                archive += f"`{ctx.guild.get_channel(results[i].value_id)}` with ID `{results[i].value_id}`\n"
 
+        emby = utils.make_embed(color=discord.Color.green(), name="Server Settings",
+                                value=f"‌\n{pub}\n {priv}\n{archive}\n{log}")
+        await ctx.send(embed=emby)
 
-		emby = utils.make_embed(color=discord.Color.green(), name="Server Settings", value=f"‌\n{pub}\n {priv}\n{archive}\n{log}")
-		await ctx.send(embed=emby)	
+    @commands.command(name="delete-setting", aliases=["ds"], help=f"Remove a channel from the list of watched 'create-voice' channels. \n\
+                        Usage: `{config.PREFIX}ds [channel-id]`, to get a list of all watched channels use `{config.PREFIX}gvc` \n\
+                        This command will only untrack the channel, it will _not_ delete anything on your server.")
+    @commands.has_permissions(administrator=True)
+    async def delete_settings(self, ctx, value):
+        """
+        remove set channels
+        """
+        if value:
+            db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
+            try:
+                int(value)  # fails when string is given
+                if len(value) == 18:
+                    # all checks passed - removing that entry
+                    db.remove_line(int(value), column="value_id")
+                    channel = ctx.guild.get_channel(int(value))
+                    await ctx.send(embed=utils.make_embed(color=discord.Color.green(), name="Deleted",
+                                                          value=f"Removed `{channel}` from settings"))
+                else:
+                    raise  # enter except
 
+            except:
+                emby = utils.make_embed(color=discord.Color.orange(), name="No valid channel ID", value="It seems like you din't \
+                                    give me a valid channel ID to work with")
+                await ctx.send(embed=emby)
+            # db.remove_line(value, column="value")
 
+        else:
+            emby = utils.make_embed(color=discord.Color.orange(), name="No input", value=f"This function requires exactly one input:\n \
+                                `channel-ID` please give a valid channel ID as argument to remove that channel from \
+                                the list of watched channels.\n \
+                                You can get a list of all watched channels with `{config.PREFIX}gs`")
 
-	@commands.command(name="delete-setting", aliases=["ds"], help=f"Remove a channel from the list of watched 'create-voice' channels. \n\
-						Usage: `{config.PREFIX}ds [channel-id]`, to get a list of all watched channels use `{config.PREFIX}gvc` \n\
-						This command will only untrack the channel, it will _not_ delete anything on your server.")
-	@commands.has_permissions(administrator=True) 
-	async def delete_settings(self, ctx, value):
-		"""
-		remove set channels
-		"""
-		if value:
-			db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
-			try:
-				int(value) #fails when string is given
-				if len(value) == 18:
-					#all checks passed - removing that entry
-					db.remove_line(int(value), column="value_id")
-					channel = ctx.guild.get_channel(int(value))
-					await ctx.send(embed=utils.make_embed(color=discord.Color.green(), name="Deleted",
-												value=f"Removed `{channel}` from settings"))
-				else:
-					raise #enter except
+            await ctx.send(embed=emby)
 
-			except:
-				emby = utils.make_embed(color=discord.Color.orange(), name="No valid channel ID", value="It seems like you din't \
-									give me a valid channel ID to work with")
-				await ctx.send(embed=emby)
-				#db.remove_line(value, column="value")
+    # command to set-edit-vc permissions
+    @commands.command(name='edit-channel', aliases=['ec'],
+                      help=f'Change wether created public VC names can be edited by the channel creator.\n\
+                Arguments: [`yes` | `no`]\n\
+                Default is `no`.')
+    @commands.has_permissions(administrator=True)
+    async def edit_channel(self, ctx, value: str):
+        settings = {'yes': 1,
+                    'no': 0}
 
-		else:
-			emby = utils.make_embed(color=discord.Color.orange(), name="No input", value=f"This function requires exactly one input:\n \
-								`channel-ID` please give a valid channel ID as argument to remove that channel from \
-								the list of watched channels.\n \
-								You can get a list of all watched channels with `{config.PREFIX}gs`")
-			
-			await ctx.send(embed=emby)
+        value_num = settings.get(value.lower())
+        if value_num != None:
+            db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
 
+            # if setting is already there old value needs to be deleted
+            if len(db.search_table(value="edit_channel",
+                                   column="setting")) == 1:  # there can only be one archive and log
+                db.remove_line('"edit_channel"', column="setting")
 
-	#command to set-edit-vc permissions
-	@commands.command(name='edit-channel', aliases=['ec'], 
-			help=f'Change wether created public VC names can be edited by the channel creator.\n\
-				Arguments: [`yes` | `no`]\n\
-				Default is `no`.')
-	@commands.has_permissions(administrator=True) 
-	async def edit_channel(self, ctx, value: str):
-		settings = {'yes': 1,
-					'no': 0}
+            entry = ("edit_channel", "value_name", value_num,
+                     time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL)
+            db.write_server_table(entry)
 
-		value_num = settings.get(value.lower())
-		if value_num != None:
-			db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
-			
-			#if setting is already there old value needs to be deleted
-			if len(db.search_table(value="edit_channel", column="setting")) == 1: #there can only be one archive and log
-				db.remove_line('"edit_channel"', column="setting")	
-			
-			entry = ("edit_channel", "value_name", value_num,\
-					time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL)				
-			db.write_server_table(entry)
-			
-			emby = utils.make_embed(color=discord.Color.green(),
-				name="Success",
-				value=f"Channel Creator can edit channel-name: {value}")
-			await ctx.send(embed=emby)
+            emby = utils.make_embed(color=discord.Color.green(),
+                                    name="Success",
+                                    value=f"Channel Creator can edit channel-name: {value}")
+            await ctx.send(embed=emby)
 
-		else:
-			emby = utils.make_embed(color=discord.Color.orange(),
-				name="Missing argument",
-				value=f"Please enter `yes` or `no` as argument.")
-			await ctx.send(embed=emby)
+        else:
+            emby = utils.make_embed(color=discord.Color.orange(),
+                                    name="Missing argument",
+                                    value=f"Please enter `yes` or `no` as argument.")
+            await ctx.send(embed=emby)
 
+    @commands.command(name="set", aliases=["sa"], help=f"Change various settings.\n\
+        `Options`:\n\
+        archive - needs category ID\n\
+        `log` - needs category ID\n\
+        `default-role` - needs role ID\n\
+        Usage: \
+        `{config.PREFIX}sa [`Option`] [needed argument]`.\n \
+        Please note that text-channels will only be archived when they contain at least one message, they'll be deleted otherwise. \n \
+        Also the `default-role` option comes with some disadvantages, e.g. new VCs aren't synced with their category\n\
+        This option is - also - admin only")
+    @commands.has_permissions(administrator=True)
+    async def set_archive(self, ctx, setting: str, value: str):
+        # possible settings switch -returns same value but nothing if key isn't valid
+        settings = {
+            "archive": utils.get_chan(ctx.guild, value),
+            "log": utils.get_chan(ctx.guild, value),
+            "default-role": utils.get_rid(ctx, [value])
+        }
+        # trying to get a corresponding channel / id
+        value = settings.get(setting)
+        # if value is "None" this means that there is no such setting or no such value for it
+        # checking if keyword mateches the entered channel type
+        # -> ensures that the process of getting a correct setting has worked
 
+        if setting == "default-role" and value is not None:
+            role = ctx.guild.get_role(value[0][0])
+            db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
 
+            # if setting is already there old value needs to be deleted
+            if len(db.search_table(value="default_role",
+                                   column="setting")) == 1:  # there can only be one archive and log
+                db.remove_line('"default_role"', column="setting")
 
-	@commands.command(name="set", aliases=["sa"], help=f"Change various settings.\n\
-		`Options`:\n\
-		archive - needs category ID\n\
-		`log` - needs category ID\n\
-		`default-role` - needs role ID\n\
-		Usage: \
-		`{config.PREFIX}sa [`Option`] [needed argument]`.\n \
-		Please note that text-channels will only be archived when they contain at least one message, they'll be deleted otherwise. \n \
-		Also the `default-role` option comes with some disadvantages, e.g. new VCs aren't synced with their category\n\
-		This option is - also - admin only")
-	@commands.has_permissions(administrator=True) 
-	async def set_archive(self, ctx, setting: str, value: str):
-		#possible settings switch -returns same value but nothing if key isn't valid
-		settings = {
-			"archive": utils.get_chan(ctx.guild, value),
-			"log": utils.get_chan(ctx.guild, value),
-			"default-role": utils.get_rid(ctx, [value])
-		}
-		#trying to get a corresponding channel / id
-		value = settings.get(setting)
-		#if value is "None" this means that there is no such setting or no such value for it
-		#checking if keyword mateches the entered channel type
-		# -> ensures that the process of getting a correct setting has worked
-		
-		if setting == "default-role" and value is not None:
-			role = ctx.guild.get_role(value[0][0])
-			db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
-			
-			#if setting is already there old value needs to be deleted
-			if len(db.search_table(value="default_role", column="setting")) == 1: #there can only be one archive and log
-				db.remove_line('"default_role"', column="setting")	
-			
-			#editing db
-			entry = ("default_role", "value_name", role.id,\
-					time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL)				
-			db.write_server_table(entry)
-			
-			#sending reply
-			emby = utils.make_embed(color=discord.Color.green(),
-				name="Success",
-				value=f"Your new defaul role is: {role.mention}")
-			await ctx.send(embed=emby)
+            # editing db
+            entry = ("default_role", "value_name", role.id,
+                     time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL)
+            db.write_server_table(entry)
 
-		#set channels
-		elif value is not None and value.type == discord.ChannelType.text and setting == "log" \
-									or value.type == discord.ChannelType.category and setting == "archive":
+            # sending reply
+            emby = utils.make_embed(color=discord.Color.green(),
+                                    name="Success",
+                                    value=f"Your new defaul role is: {role.mention}")
+            await ctx.send(embed=emby)
 
-			#conneting to db - creating a new one if there is none yet
-			db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
+        # set channels
+        elif value is not None and value.type == discord.ChannelType.text and setting == "log" \
+                or value.type == discord.ChannelType.category and setting == "archive":
 
-			#Settings won't be storred if max watched channels are reached
-			#-> searching for amount of matching entries
-			if len(db.search_table(value=setting, column="setting")) >= 1: #there can only be one archive and log
+            # conneting to db - creating a new one if there is none yet
+            db = sqltils.DbConn(db_file, ctx.guild.id, "setting")
 
-				text = f"Hey, you can only have one archive and log at once\n \
-						If you wanna change those settings use `{config.PREFIX}ds [channel-id]` to remove a channel from your settings"				
-				emby = utils.make_embed(color=discord.Color.orange(), name= "Too many entries", value=text)
-				await ctx.send(embed=emby)
-			
-			#writing entry to db - the way things sould go
-			else:
-				entry = (setting, "value_name", value.id, time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL)
-				db.write_server_table(entry)
+            # Settings won't be storred if max watched channels are reached
+            # -> searching for amount of matching entries
+            if len(db.search_table(value=setting, column="setting")) >= 1:  # there can only be one archive and log
 
-				emby = utils.make_embed(color=discord.Color.green(), name= "Success", value="Setting saved")
-				await ctx.send(embed=emby)
+                text = f"Hey, you can only have one archive and log at once\n \
+                        If you wanna change those settings use `{config.PREFIX}ds [channel-id]` to remove a channel from your settings"
+                emby = utils.make_embed(color=discord.Color.orange(), name="Too many entries", value=text)
+                await ctx.send(embed=emby)
 
-		#when false inputs were given
-		else:
-			value = ("Please ensure that you've entered a valid setting \
-					and channel-id or role-id for that setting.")
-			emby = utils.make_embed(color=discord.Color.orange(), name="Can't get setting", value=value)
-			await ctx.send(embed=emby)
+            # writing entry to db - the way things sould go
+            else:
+                entry = (setting, "value_name", value.id, time.strftime("%Y-%m-%d %H:%M:%S"), config.VERSION_SQL)
+                db.write_server_table(entry)
 
+                emby = utils.make_embed(color=discord.Color.green(), name="Success", value="Setting saved")
+                await ctx.send(embed=emby)
+
+        # when false inputs were given
+        else:
+            value = ("Please ensure that you've entered a valid setting \
+                    and channel-id or role-id for that setting.")
+            emby = utils.make_embed(color=discord.Color.orange(), name="Can't get setting", value=value)
+            await ctx.send(embed=emby)
 
 
 def setup(bot):
-	bot.add_cog(Settings(bot))
-
+    bot.add_cog(Settings(bot))

--- a/src/fury-bot.py
+++ b/src/fury-bot.py
@@ -36,7 +36,8 @@ initial_extensions = [
         'cogs.misc',
         'cogs.on_message',
         'cogs.set_settings',
-        'cogs.on_voice_update'
+        'cogs.on_voice_update',
+        'cogs.mod_commands'
             ]    
 
 # Here we load our extensions(cogs) listed above in [initial_extensions].


### PR DESCRIPTION
Bot can now split members into breakout rooms of a given size.
- new voice channels will be created
- members will be distributed to breakout rooms

This functionality makes use of the previous function to create custom VCs on demand.
Hence the 'behavior' of breakout rooms is the same.
- liked text channels will be created
- empty channels will be deleted
- empty text channels are deleted or archived

Channels can also be closed - all members will be moved to the VC of the command issuer

Commands:
Create breakout rooms: `f!break-out [amount]` - aliases: `bor` / `brout`
Collect members: `f!close-rooms` - aliases: `cbr` / `clbr`

These commands are located in a new module/ cog named `mod_commands` and require kick-permissions at the moment.
