### PR TITLE
Merge commands to add settings into one, introduce custom prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 * Create custom voice channels with linked text channels on demand.  
 * Add breakout rooms for discord
 
-## Commands channels and breakout rooms:
+## Commands channels and breakout rooms
+Default prefix is `f!`  
+The bot also listens for mentions, so `@[bot] help` is also a valid command.  
+Note that the default prefix can be changed on a guild since `v2.0.1`  
+
 | Command | Description | Alternative |  
 | ------ |   ------ | ------- | 
 | `f!help [optional: module name]` | Shows the help message with all modules / for entered module | `f!h` |
@@ -12,16 +16,32 @@
 | `f!add [public / private] [channel id]` | Register a voice channel as tracked creation channel | `svc`, `set-voice`|
 
 ## Settings
-| Command | Description | Alternative |  
-| ------ |   ------ | ------- | 
-| `f!set [log channel / archive category] [channel]` | Add setting for archive category and log channel | `archive`, `log` |
-| `f!set prefix [prefix]` | Use custom prefix on your server | same as above |
-| `f!delete-settings [channel id]` | Removes a channel from the tracked list | `ds` |
-| `f!settings` | Get a list of all configured settings | `gs`, `get-settings` |
-| `f!allow-edit [yes / no]` | Allow the creator of a public channel to edit the name, default is no | `al`, `ae` |
-| `f!ping` | Check if the bot is available | |
-The bot also listens for mentions, so `@bot help` is also a valid command.  
-Not that the default prefix can be changed on a guild since `v2.0.1`
+Syntax for the following commands is `f!set [name] [value]`  
+
+| Name | Value | Description | Entry limit |  
+| ------ | ------ | ------- | ------ |  
+| `public` | `voice-channel-id` | Track a channel for the creation of public channels   | 3 |  
+| `private` | `voice-channel-id` | Track a channel for the creation of private channels   | 3 |  
+| `archive` | `category-id` | Add setting for archive category and log channel | 1 |  
+| `log` | `text-channel-id` | Add setting for archive category and log channel | 1 |  
+| `prefix` | New Prefix | Use custom prefix on your server | 1 |  
+| `allow-edit` | `yes` or `no` | Allow the creator of a public channel to edit the name, default is no | 1 |  
+
+If a setting is already set it will be updated to the new value.  
+
+### Delete a setting
+Syntax for the following commands is   
+
+`f!ds [name] [value]`  
+
+Delete a tracked channel by giving the channel id.  
+Another setting can be deleted by entering it's setting name, like `f!ds prefix`  
+
+## Other commands
+| Name |  Description | Alternative |  
+| ------ |   ------ | ------- |  
+| `f!settings` | Get a list of all configured settings | `gs`, `get-settings` |  
+| `f!ping` | Check if the bot is available | |  
 
 ## Functions:
 ### Create voice channels on demand

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@
 ## Settings
 | Command | Description | Alternative |  
 | ------ |   ------ | ------- | 
-| `f!set [log channel / archive category]` | Add setting for archive category and log channel | `archive`, `log` |
+| `f!set [log channel / archive category] [channel]` | Add setting for archive category and log channel | `archive`, `log` |
+| `f!set prefix [prefix]` | Use custom prefix on your server | same as above |
 | `f!delete-settings [channel id]` | Removes a channel from the tracked list | `ds` |
 | `f!settings` | Get a list of all configured settings | `gs`, `get-settings` |
 | `f!allow-edit [yes / no]` | Allow the creator of a public channel to edit the name, default is no | `al`, `ae` |
 | `f!ping` | Check if the bot is available | |
+The bot also listens for mentions, so `@bot help` is also a valid command.  
+Not that the default prefix can be changed on a guild since `v2.0.1`
 
 ## Functions:
 ### Create voice channels on demand
@@ -69,6 +72,7 @@ Run the bot using `docker-compose` using the image from Docker Hub `nonchris/dis
 | OWNER_ID | no | To mention the owner if on server | 100000000000000000 |
 | OWNER_NAME | no | To give the owners name if not on server | unknown |
 | CHANNEL_TRACK_LIMIT | no | Limit of tracked channels per server per type | 20 |
+| MAX_PREFIX_LENGTH | no | Max length for a custom prefix | 3 |
 
 
 ### Update from old v1.x.x database structure to v2.0.0

--- a/src/cogs/on_voice_update.py
+++ b/src/cogs/on_voice_update.py
@@ -83,7 +83,7 @@ async def create_new_channels(member: discord.Member,
     """
 
     # check if creator is allowed to rename a public channel
-    allowed_to_edit = settings_db.get_all_settings_for(member.guild.id, "edit_public")
+    allowed_to_edit = settings_db.get_first_setting_for(member.guild.id, "allow_public_rename")
 
     # get channel names from dict above
     new_channel_name = random.choice(channel_names[channel_type])
@@ -105,7 +105,7 @@ async def create_new_channels(member: discord.Member,
         }
 
     # set extra permissions for creator if creators are allowed to edit public channels on this server
-    elif allowed_to_edit:
+    elif allowed_to_edit and int(allowed_to_edit.value):
         voice_channel_permissions[member] = discord.PermissionOverwrite(connect=True,
                                                                         manage_channels=True)
 

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -133,7 +133,8 @@ class Settings(commands.Cog):
         """
 
         tracked_channels = []
-        for setting in settings.values():
+        # conversion to set since some keys appear multiple times due to aliases
+        for setting in set(settings.values()):
             entries = settings_db.get_all_settings_for(ctx.guild.id, setting)
             if entries:
                 tracked_channels.extend(entries)
@@ -142,7 +143,7 @@ class Settings(commands.Cog):
         priv = "__Private Channels:___\n"
         log = "__Log Channel:__\n"
         archive = "__Archive Category:__\n"
-        prefix = "__Prefixes:__"
+        prefix = "__Prefixes:__\n"
         if not tracked_channels:
             emb = utils.make_embed(color=utils.yellow, name="No configuration yet",
                                    value="You didn't configure anything yet.\n"

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -11,12 +11,24 @@ import database.access_channels_db as channels_db
 import utils as utils
 
 # possible settings switch - returns same value but nothing if key isn't valid
+# used to verify that input is correct and to make sure that we always handle the same name internally
+
 settings = {
     "archive": "archive_category",
     "achive": "archive_category",
     "arch": "archive_category",
     "log": "log_channel",
     "prefix": "prefix",
+
+    "pub-channel": "public_channel",
+    "public-channel": "public_channel",
+    "pub": "public_channel",
+    "public": "public_channel",
+
+    "priv-channel": "private_channel",
+    "private-channel": "private_channel",
+    "priv": "private_channel",
+    "private": "private_channel",
 }
 
 
@@ -45,26 +57,9 @@ class Settings(commands.Cog):
         :param value: id or mention the channel to be entered into the database
         """
 
-        # channel to be returned with dict
-        # cache variable - the function would be called for each key if we'd place it in each tuple of the dict
-        _channel = utils.get_chan(ctx.guild, value)
-
-        # 'translation' dict
-        # used to verify that input is correct and to make sure that we always handle the same name internally
-        settings = {
-            "pub-channel": ("public_channel", _channel),
-            "public-channel": ("public_channel", _channel),
-            "pub": ("public_channel", _channel),
-            "public": ("public_channel", _channel),
-
-            "priv-channel": ("private_channel", _channel),
-            "private-channel": ("private_channel", _channel),
-            "priv": ("private_channel", _channel),
-            "private": ("private_channel", _channel),
-        }
-
         # trying to get a corresponding channel / id
-        setting, channel = settings[setting]
+        setting = settings[setting]
+        channel = utils.get_chan(ctx.guild, value)
 
         # if channel is "None" this means that there is no such setting or no such channel for it
         # -> ensures that the process of getting a correct setting has worked

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -391,20 +391,29 @@ class Settings(commands.Cog):
              f"Aliases: `archive`, `log`, `sa`, `sl`\n\n"
              "This option is admin only")
     @commands.has_permissions(administrator=True)
-    async def set_setting(self, ctx: commands.Context, setting: str, value: str):
+    async def set_setting(self, ctx: commands.Context, *params):
+        # first param setting name, second param setting value
+        syntax = "Example: `set [setting name] [setting value]`"
+        try:
+            setting = params[0]
 
-        if not setting:
-            msg = ("Please ensure that you've entered a valid setting \
-                                and channel-id or role-id for that setting.")
-            emby = utils.make_embed(color=discord.Color.orange(), name="Can't get setting", value=msg)
+        except IndexError:
+
+            msg = (f"Please ensure that you've entered a valid setting \
+                                and channel-id or role-id for that setting.\n{syntax}")
+            emby = utils.make_embed(color=discord.Color.orange(), name="Can't get setting name", value=msg)
             await ctx.send(embed=emby)
 
             return
 
-        if not value:
-            msg = ("Please ensure that you've entered a valid setting \
-                                            and channel-id or role-id for that setting.")
-            emby = utils.make_embed(color=discord.Color.orange(), name="Can't get setting", value=msg)
+        try:
+            value = params[1]
+
+        except IndexError:
+
+            msg = (f"Please ensure that you've entered a valid \
+            channel-id / role-id or other required parameter for that setting.\n{syntax}")
+            emby = utils.make_embed(color=discord.Color.orange(), name="Can't get value", value=msg)
             await ctx.send(embed=emby)
 
             return

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -40,85 +40,6 @@ class Settings(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(
-        name="add", aliases=["svc", "set-voice", "set-voice-channel"],
-        help=f"Register a voice channel that members can join to get an own channel\n\n"
-        "__Usage:__\n"
-        f"`{PREFIX}add` [_public_ | _private_] [_channel-id_]\n\n"
-        "_public_ or _private_ is the option for the channel-type that is created when joining the tracked-channel.\n"
-        "This option is - obviously - admin only\n\n"
-        f"Aliases: `{PREFIX}svc` `{PREFIX}set-voice [channel type] [channel id]`")
-    @commands.has_permissions(administrator=True)
-    async def set_voice(self, ctx: commands.Context, setting: str, value: str):
-        """
-        Add a voice channel setting to the database
-        :param ctx: command context
-        :param setting: setting to be added like 'public'
-        :param value: id or mention the channel to be entered into the database
-        """
-
-        # trying to get a corresponding channel / id
-        setting = settings[setting]
-        channel = utils.get_chan(ctx.guild, value)
-
-        # if channel is "None" this means that there is no such setting or no such channel for it
-        # -> ensures that the process of getting a correct setting has worked
-        if channel is None:
-            emby = utils.make_embed(
-                color=discord.Color.orange(),
-                name="Can't get setting",
-                value="Please ensure that you've entered a valid setting and channel-id for that setting.")
-            await ctx.send(embed=emby)
-            return
-
-        # if channel type is not voice channel
-        if type(channel) is not discord.VoiceChannel:
-            embed = utils.make_embed(
-                name='Not a voice channel',
-                value=f"The channel {channel.name} is no voice channel, please enter a valid channel-id",
-                color=utils.yellow
-            )
-            await ctx.send(embed=embed)
-            return
-
-        # Settings won't be stored if max watched channels are reached
-        # -> searching for amount of matching entries
-        entries = settings_db.get_all_settings_for(ctx.guild.id, setting)
-        if entries and len(entries) >= CHANNEL_TRACK_LIMIT:
-            emby = utils.make_embed(
-                color=utils.orange, name="Too many entries",
-                value=f"Hey, you can't make me watch more than {CHANNEL_TRACK_LIMIT} channels for this setting\n"
-                      f"If you wanna change the channels I watch use `{PREFIX}ds [channel-id]` "
-                      f"to remove a channel from your settings")
-
-            await ctx.send(embed=emby)
-            return
-
-        # check if channel was already given to track
-        session = db_models.open_session()
-        entry: Union[db_models.Settings, None] = settings_db.get_setting_by_value(ctx.guild.id, channel.id, session)
-
-        # if channel is already registered - update
-        if entry:
-            entry.setting = setting
-
-            session.add(entry)
-            session.commit()
-
-        # create new entry, channel not tracked yet
-        else:
-            # write entry to db
-            settings_db.add_setting(
-                guild_id=ctx.guild.id,
-                setting=setting,
-                value=channel.id,
-                set_by=ctx.author.id,
-            )
-
-        emby = utils.make_embed(
-            color=utils.green, name="Success", value=f"Set {channel.name} as {setting.replace('_', ' ')}")
-        await ctx.send(embed=emby)
-
     @commands.command(name="settings", aliases=["gs", "get-settings"],
                       help=f"Get a list of all 'watched' channels as well as all other settings\n\n"
                            f"Aliases: `gs`, `get-settings` ")
@@ -271,7 +192,6 @@ class Settings(commands.Cog):
                                 footer="Note that this setting has no affect on private channels")
         await ctx.send(embed=emby)
 
-
     @staticmethod
     async def validate_channel(ctx: commands.Context, channel_id: str):
 
@@ -285,7 +205,6 @@ class Settings(commands.Cog):
                                                   color=utils.orange))
 
         return set_channel
-
 
     @staticmethod
     async def channel_from_input(ctx, channel_type: str, channel_id: str) -> Union[Tuple[str, str], Tuple[None, None]]:
@@ -311,6 +230,30 @@ class Settings(commands.Cog):
 
         elif type(set_channel) == discord.CategoryChannel and channel_type == "archive_category":
             return str(set_channel.id), set_channel.name
+
+        elif type(set_channel) == discord.VoiceChannel and channel_type in ['public_channel', 'private_channel']:
+
+            # check if max for tracked channels is reached
+            if not settings_db.is_track_limit_reached(ctx.guild.id, channel_type):
+                return str(set_channel.id), set_channel.name
+
+            await ctx.send(embed=utils.make_embed(
+                color=utils.orange, name="Too many entries",
+                value=f"Hey, you can't make me watch more than {CHANNEL_TRACK_LIMIT} channels for this setting\n"
+                      f"If you wanna change the channels I watch use `{PREFIX}ds [channel-id]` "
+                      f"to remove a channel from your settings"))
+            return None, None
+
+        else:
+            # gained channel and required type didn't match
+            await ctx.send(embed=utils.make_embed(
+                name='Not a voice channel',
+                value=f"The channel {set_channel.name} is no {channel_type.replace('_', ' ')}, "
+                      f"please enter a valid channel-id",
+                color=utils.yellow
+            ))
+
+        return None, None
 
     @staticmethod
     async def prefix_validation(ctx: commands.Context, new_prefix: str) -> Union[Tuple[str, str], Tuple[None, None]]:
@@ -341,9 +284,80 @@ class Settings(commands.Cog):
             color=utils.yellow))
         return None, None
 
+    @staticmethod
+    async def send_setting_updated(ctx: commands.Context, setting_name: str, value_name: str):
+        """
+        Send a message that the setting was updated
+
+        :param ctx: command context
+        :param setting_name: name of the setting like, 'private_channel'
+        :param value_name: name the set value should have in bot message
+        """
+        nice_string = setting_name.replace('_', ' ')
+        await ctx.send(embed=utils.make_embed(name=f"_Updated_ setting: {nice_string}",
+                                              value=f"Set to {value_name}",
+                                              color=utils.green))
+
+    @staticmethod
+    async def send_setting_added(ctx: commands.Context, setting_name: str, value_name: str):
+        """
+        Send a message that the setting as created
+
+        :param ctx: command context
+        :param setting_name: name of the setting, like 'private_channel'
+        :param value_name: name the set value should have in bot message
+        """
+        nice_string = setting_name.replace('_', ' ')
+        await ctx.send(embed=utils.make_embed(name=f"Added setting: {nice_string}",
+                                              value=f"Set to {value_name}",
+                                              color=utils.green))
+
+    @staticmethod
+    async def update_value_or_create_entry(ctx: commands.Context, setting_name: str, set_value: str, value_name: str):
+        """
+        Check if an entry exists based on setting name, alter its value\n
+        Create a new entry if no setting was found\n
+        -> If there is a setting with the name 'prefix' update setting.value = new_prefix\n
+        Send update messages on discord
+
+        :param ctx: command context
+        :param setting_name: name of the setting
+        :param set_value: value the setting shall be set to
+        :param value_name: name the set value should have in bot message
+
+        """
+        # check if there is an entry for that setting - toggle it
+        session = db_models.open_session()
+
+        entry = settings_db.get_first_setting_for(ctx.guild.id, setting_name, session=session)
+
+        if entry:
+            # TODO: SEND REPLY
+            entry.value = set_value
+            session.add(entry)
+            session.commit()
+
+            await Settings.send_setting_updated(ctx, setting_name, value_name)
+
+            return
+
+        settings_db.add_setting(
+            guild_id=ctx.guild.id,
+            setting=setting_name,
+            value=set_value,
+            set_by=f"{ctx.author.id}"
+        )
+        await Settings.send_setting_added(ctx, setting_name, value_name)
+
     @commands.command(
-        name="set", aliases=["sa", "sl", "archive", "log"],
-        help=f"Change settings for:\n\n"
+        name="set", aliases=["sa", "sl", "archive", "log", "add", "svc", "set-voice", "set-voice-channel"],
+        help=f"__**Configure Voice Channel behaviour**__:\n"
+             f"Register a voice channel that members can join to get an own channel\n\n"
+             "__Usage:__\n"
+             f"`{PREFIX}set` [_public_ | _private_] [_channel-id_]\n\n"
+             "_public_ or _private_ is the option for the channel-type that's created when joining the channel.\n\n"
+             f""
+             f"__**Other  settings:**__\n\n"
              f"__log:__\n"
              f"Channel for log messages\n"
              f"__archive:__\n"
@@ -380,7 +394,6 @@ class Settings(commands.Cog):
         # look if setting name is valid
         setting = setting.lower()  # dict only handles lower case, so do we all the time
         setting_type = settings.get(setting, None)
-        nice_string = setting_type.replace('_', ' ')
 
         if not setting_type:
             await ctx.send(embed=utils.make_embed(name=f"'{setting}' is no valid setting name",
@@ -391,42 +404,57 @@ class Settings(commands.Cog):
         # setting is validated, let's see if the value matches the required setting
         value = value.strip()  # just in case
         set_value, set_name = None, None
+
+        # first check 'easy' cases
         if setting_type in ['archive_category', 'log_channel']:
             # trying to get a corresponding channel (id: str, name/ mention: str)
             set_value, set_name = await self.channel_from_input(ctx, setting_type, value)
 
-        if setting_type == "prefix":
+        elif setting_type == "prefix":
             # need to await since it sends the error message if we can't match
             set_value, set_name = await self.prefix_validation(ctx, value)
 
-        # make database entry
+        # enter to database if value is correct
         if set_value:
+            await self.update_value_or_create_entry(ctx, setting_type, set_value, set_name)
+            return  # we're done - the other handling isn't needed
 
-            # check if there is an entry for that setting - toggle it
+        # now handle tracked channels
+        # tracked channels require an other database handling as the other settings
+        # we need to check if there is a setting with that value and adjust the setting_name
+        # in all other cases it's we check the settings name and alter the value...
+        # e.g. if there is a setting for setting.value == channel_id change setting.name to channel_type
+        if setting_type in ['public_channel', 'private_channel']:
+            # trying to get a corresponding channel (id: str, name/ mention: str)
+            set_value, set_name = await self.channel_from_input(ctx, setting_type, value)
+
             session = db_models.open_session()
-            entry = settings_db.get_first_setting_for(ctx.guild.id, setting_type, session=session)
+            entry: Union[db_models.Settings, None] = settings_db.get_setting_by_value(ctx.guild.id, set_value, session)
 
-            if entry:
-                # TODO: SEND REPLY
-                entry.value = set_value
-                session.add(entry)
-                session.commit()
-
-                await ctx.send(embed=utils.make_embed(name=f"Updated setting: {nice_string}",
-                                                      value=f"Set to {set_name}",
-                                                      color=utils.green))
-
+            # given channel id seems flawed - returning
+            if not set_value:
                 return
 
-            settings_db.add_setting(
-                guild_id=ctx.guild.id,
-                setting=setting_type,
-                value=set_value,
-                set_by=f"{ctx.author.id}"
-            )
-            await ctx.send(embed=utils.make_embed(name=f"Added setting: {nice_string}",
-                                                  value=f"Set to {set_name}",
-                                                  color=utils.green))
+            # if channel is already registered - update
+            if entry:
+                entry.setting = setting_type
+
+                session.add(entry)
+                session.commit()
+                await self.send_setting_updated(ctx, setting_type, set_name)
+                return
+
+            # create new entry, channel not tracked yet
+            else:
+                # write entry to db
+                settings_db.add_setting(
+                    guild_id=ctx.guild.id,
+                    setting=setting_type,
+                    value=set_value,
+                    set_by=ctx.author.id,
+                )
+                await self.send_setting_updated(ctx, setting_type, set_name)
+                return
 
 
 def setup(bot):

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -203,8 +203,9 @@ class Settings(commands.Cog):
             return
 
         # get channel setting or setting string
-        setting = utils.extract_id_from_message(value) or settings.get(value, None)
-        if not setting:
+        setting_setting = settings.get(value, None)  # name of setting
+        value_setting = utils.extract_id_from_message(value)  # id / value of setting
+        if not (setting_setting or value_setting):
             emby = utils.make_embed(color=utils.orange,
                                     name="No valid setting",
                                     value="It seems like you didn't give me a valid channel ID or "
@@ -213,12 +214,17 @@ class Settings(commands.Cog):
             return
 
         # all checks passed - removing that entry
-        settings_db.del_setting_by_setting(ctx.guild.id, setting)
+        if setting_setting:
+            settings_db.del_setting_by_setting(ctx.guild.id, setting_setting)
 
-        channel = ctx.guild.get_channel(setting)
+        elif value_setting:
+            settings_db.del_setting_by_value(ctx.guild.id, str(value_setting))
+
+        # channel only applied to setting by value
+        channel = ctx.guild.get_channel(value_setting)
         await ctx.send(embed=utils.make_embed(color=utils.green, name="Deleted",
                                               value=f"Removed "
-                                                    f"`{channel.name if channel else setting}` from settings"))
+                                                    f"`{channel.name if channel else setting_setting}` from settings"))
 
     # command to set-edit-vc permissions
     @commands.command(name='allow-edit', aliases=['al', 'ae'],

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -123,15 +123,24 @@ class Settings(commands.Cog):
         prints setting on guild
         """
 
-        tracked_channels = [*settings_db.get_all_settings_for(ctx.guild.id, "public_channel"),
-                            *settings_db.get_all_settings_for(ctx.guild.id, "private_channel"),
-                            *settings_db.get_all_settings_for(ctx.guild.id, "archive_category"),
-                            *settings_db.get_all_settings_for(ctx.guild.id, "log_channel")]
+        tracked_channels = []
+        for setting in settings.values():
+            entries = settings_db.get_all_settings_for(ctx.guild.id, setting)
+            if entries:
+                tracked_channels.extend(entries)
 
         pub = "__Public Channels:__\n"
         priv = "__Private Channels:___\n"
         log = "__Log Channel:__\n"
         archive = "__Archive Category:__\n"
+        prefix = "__Prefixes:__"
+        if not tracked_channels:
+            emb = utils.make_embed(color=utils.yellow, name="No configuration yet",
+                                   value="You didn't configure anything yet.\n"
+                                         "Use the help command or try the quick-setup to get started :)")
+            await ctx.send(embed=emb)
+            return
+
         for i, elm in enumerate(tracked_channels):  # building strings
             if elm.setting == "public_channel":
                 pub += f"`{ctx.guild.get_channel(int(elm.value))}` with ID `{elm.value}`\n"
@@ -144,13 +153,16 @@ class Settings(commands.Cog):
 
             elif elm.setting == "archive_category":
                 archive += f"`{ctx.guild.get_channel(int(elm.value))}` with ID `{elm.value}`\n"
+            elif elm.setting == "prefix":
+                prefix += f"`{elm.value}` example `{elm.value}help`\n"
 
         emby = utils.make_embed(color=utils.blue_light, name="Server Settings",
                                 value=f"‌\n"
                                       f"{pub}\n"
                                       f"{priv}\n"
                                       f"{archive}\n"
-                                      f"{log}")
+                                      f"{log}\n"
+                                      f"{prefix}")
         await ctx.send(embed=emby)
 
     @commands.command(name="delete-setting", aliases=["ds"],

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -265,6 +265,22 @@ class Settings(commands.Cog):
                                 footer="Note that this setting has no affect on private channels")
         await ctx.send(embed=emby)
 
+
+    @staticmethod
+    async def validate_channel(ctx: commands.Context, channel_id: str):
+
+        set_channel = utils.get_chan(ctx.guild, channel_id)
+
+        if set_channel is None:
+            await ctx.send(embed=utils.make_embed(name="No valid channel id",
+                                                  value="I can't find a channel / category that matches your input.\n"
+                                                        "Please make sure that I can see the channel "
+                                                        "and that the given id is valid.",
+                                                  color=utils.orange))
+
+        return set_channel
+
+
     @staticmethod
     async def channel_from_input(ctx, channel_type: str, channel_id: str) -> Union[Tuple[str, str], Tuple[None, None]]:
         """
@@ -278,8 +294,10 @@ class Settings(commands.Cog):
 
         :returns: (channel id as string, best way to mention / name channel) if found, else (None, None)
         """
+        set_channel = await Settings.validate_channel(ctx, channel_id)
 
-        set_channel = utils.get_chan(ctx.guild, channel_id)
+        if set_channel is None:
+            return None, None
 
         # check if channel type and wanted setting match
         if type(set_channel) == discord.TextChannel and channel_type == "log_channel":
@@ -287,14 +305,6 @@ class Settings(commands.Cog):
 
         elif type(set_channel) == discord.CategoryChannel and channel_type == "archive_category":
             return str(set_channel.id), set_channel.name
-
-        await ctx.send(embed=utils.make_embed(name="No valid channel id",
-                                              value="I can't find a channel / category that matches your input.\n"
-                                                    "Please make sure that I can see the channel "
-                                                    "and that the given id is valid.",
-                                              color=utils.orange))
-
-        return None, None
 
     @staticmethod
     async def prefix_validation(ctx: commands.Context, new_prefix: str) -> Union[Tuple[str, str], Tuple[None, None]]:

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -205,22 +205,23 @@ class Settings(commands.Cog):
             await ctx.send(embed=emby)
             return
 
-        channel_id = utils.extract_id_from_message(value)
-        if not channel_id:
-
+        # get channel setting or setting string
+        setting = utils.extract_id_from_message(value) or settings.get(value, None)
+        if not setting:
             emby = utils.make_embed(color=utils.orange,
-                                    name="No valid channel ID",
-                                    value="It seems like you didn't give me a valid channel ID to work with")
+                                    name="No valid setting",
+                                    value="It seems like you didn't give me a valid channel ID or "
+                                          "setting name to work with")
             await ctx.send(embed=emby)
             return
 
         # all checks passed - removing that entry
-        settings_db.del_setting_by_value(ctx.guild.id, channel_id)
+        settings_db.del_setting_by_setting(ctx.guild.id, setting)
 
-        channel = ctx.guild.get_channel(channel_id)
+        channel = ctx.guild.get_channel(setting)
         await ctx.send(embed=utils.make_embed(color=utils.green, name="Deleted",
                                               value=f"Removed "
-                                                    f"`{channel.name if channel else channel_id}` from settings"))
+                                                    f"`{channel.name if channel else setting}` from settings"))
 
     # command to set-edit-vc permissions
     @commands.command(name='allow-edit', aliases=['al', 'ae'],

--- a/src/database/access_settings_db.py
+++ b/src/database/access_settings_db.py
@@ -146,12 +146,31 @@ def del_setting(guild_id: int, setting: str, value: Union[str, int]):
     session.commit()
 
 
-def del_setting_by_value(guild_id: int, value: Union[str, int]):
+def del_setting_by_setting(guild_id: int, setting: str):
     """
-    Delete an entry from the settings table
+    Delete an entry from the settings table by giving only the settings name
 
     :param guild_id: id the setting is in
-    :param value: value of the setting - probably name of a word-list
+    :param setting: the setting - like archive or prefix
+    """
+
+    session = db.open_session()
+    statement = delete(db.Settings).where(
+        and_(
+            db.Settings.guild_id == guild_id,
+            db.Settings.setting == setting
+        )
+    )
+    session.execute(statement)
+    session.commit()
+
+
+def del_setting_by_value(guild_id: int, value: Union[str, int]):
+    """
+    Delete an entry from the settings table by giving only the value
+
+    :param guild_id: id the setting is in
+    :param value: value of the setting like a channel id
     """
 
     if type(value) is int:

--- a/src/database/db_models.py
+++ b/src/database/db_models.py
@@ -59,8 +59,14 @@ class Settings(Base):
     set_date = Column(DateTime)     # date the setting was altered the last time
 
     def __repr__(self):
-        return f"<Setting: guild='{self.guild_id}', channel_id='{self.applied_to_channel_id}' setting='{self.setting}'," \
-               f"value='{self.value}', set_by='{self.set_by}', set_date='{self.set_date}', is_active='{self.is_active}'>"
+        return f"<Setting: id='{self.id}', " \
+               f"guild='{self.guild_id}', " \
+               f"channel_id='{self.applied_to_channel_id}' " \
+               f"setting='{self.setting}'," \
+               f"value='{self.value}', " \
+               f"set_by='{self.set_by}', " \
+               f"set_date='{self.set_date}', " \
+               f"is_active='{self.is_active}'>"
 
 
 class CreatedChannels(Base):

--- a/src/database/db_models.py
+++ b/src/database/db_models.py
@@ -47,7 +47,7 @@ class Settings(Base):
     __tablename__ = 'SETTINGS'
 
     # setting names:
-    # mod_role, public_channel, private_channel, archive_category, log_channel, allow_public_rename
+    # mod_role, public_channel, private_channel, archive_category, log_channel, allow_public_rename, prefix
 
     id = Column(Integer, primary_key=True)
     guild_id = Column(BigInteger)      # ID of guild setting is applied to

--- a/src/environment.py
+++ b/src/environment.py
@@ -30,6 +30,7 @@ TOKEN = os.getenv("TOKEN")  # reading in the token from environment
 
 # loading optional env variables
 PREFIX = load_env("PREFIX", "f!")
+MAX_PREFIX_LENGTH = int(load_env("MAX_PREFIX_LENGTH", "3"))  # length including the non-letter char
 VERSION = load_env("VERSION", "unknown")  # version of the bot
 OWNER_NAME = load_env("OWNER_NAME", "unknown")  # owner name with tag e.g. pi#3141
 OWNER_ID = int(load_env("OWNER_ID", "100000000000000000"))  # discord id of the owner

--- a/src/fury-bot.py
+++ b/src/fury-bot.py
@@ -66,14 +66,39 @@ async def on_command_error(ctx, error):
     Overwriting command error handler from discord.py
     """
     if isinstance(error, commands.errors.CheckFailure):
-        await ctx.send('You can\'t do that. Pleases ask an Admin')
+        await ctx.send(embed=utils.make_embed(
+            name="Permission error",
+            value=f"{error}\n"
+                  f"Please ask an admin for help.",
+            color=utils.orange,
+            footer="Is this an error? Please report it under github.com/nonchris/discord-fury/issues"
+        ))
+        logger.info(f"There was an permission error calling '{ctx.command.qualified_name}'")
 
     elif isinstance(error, commands.errors.CommandNotFound):
-        await utils.send_embed(ctx,
-                               utils.make_embed(name="I'm sorry, I don't know this command", value=f'`{error}`',
-                                                color=discord.Color.orange()))
+        await ctx.send(embed=utils.make_embed(
+            name="I'm sorry :sweat_smile:",
+            value=f'`{error}`',
+            color=discord.Color.orange()
+        ))
+        logger.warning(f"{error}")
 
-    logger.warning(f"Command tried: {error}")
+    elif isinstance(error, commands.CommandInvokeError):
+        original = error.original
+        if not isinstance(original, discord.HTTPException):
+            traceback.print_tb(original.__traceback__)
+            logger.warning(f'In {ctx.command.qualified_name}:\n'
+                           f'{original.__class__.__name__}: {original}')
+        else:
+            logger.info(f"HTTPException occurred:\n{error}")
+
+    elif isinstance(error, commands.ArgumentParsingError):
+        logger.warning(f"{error}")
+        await ctx.send(embed=utils.make_embed(
+            name="There was an error with your input",
+            value=error,
+            color=utils.yellow
+        ))
 
 
 # TODO recreate 'normal' print stack-trace... disable custom handling until then

--- a/src/fury-bot.py
+++ b/src/fury-bot.py
@@ -46,7 +46,6 @@ async def on_command_error(ctx, error):
     """
     Overwriting command error handler from discord.py
     """
-    print(error)
     if isinstance(error, commands.errors.CheckFailure):
         await ctx.send('You can\'t do that. Pleases ask an Admin')
 


### PR DESCRIPTION
# main change
There is now one command for all settings called `f!set`.  
It unifies:
* The `old set` command for log and archive
* The `set-voice-channel` command
* The `allow-edit` command

The switching between those different settings is done in the main function of the set-command.  
It uses the help of a few extra functions called from there.

All commands work the same way:  
`[prefix]command [name of setting] [settings value]`  

# other changes
* Bot now supports custom prefixes (can be set via `set` command)
* Bot now listens for mentions as prefix
* Improve `on_command_error()` listener
