### PR TITLE
Text Channels for static channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 ### Functions
 #### Create voice channels on demand
 Watches custom configured voice channels and creates a new channel for each user that joins one of those channels._  
-Supports two 'types' of channels:
+Supports three 'types' of channels:
 * public channel - synced with category, everyone has the same permissions  
 * private channel - join is disabled for every member, the creator can edit the whole channel
+* static channel - only a new linked text-channel will be created when a user joins a persistent channel
 This function also creates a 'linked' text channel which is only visible for the users that are currently in that voice chat.
 * The text channel will be removed / archived - according to your settings - when the voice channel is empty and gets deleted.
 
@@ -52,6 +53,7 @@ Syntax for the following commands is `f!set [name] [value]`
 | ------ | ------ | ------- | ------ |  
 | `public` | `voice-channel-id` | Track a channel for the creation of public channels   | 3 |  
 | `private` | `voice-channel-id` | Track a channel for the creation of private channels   | 3 |  
+| `static` | `voice-channel-id` | Create linked text channels for a persistent voice channel   | 3 |  
 | `archive` | `category-id` | Add setting for archive category and log channel | 1 |  
 | `log` | `text-channel-id` | Add setting for archive category and log channel | 1 |  
 | `prefix` | New Prefix | Use custom prefix on your server | 1 |  

--- a/src/cogs/admin.py
+++ b/src/cogs/admin.py
@@ -10,6 +10,8 @@ from discord.ext import commands
 # own
 from environment import PREFIX, OWNER_NAME, OWNER_ID
 import utils
+import database.access_settings_db as settings_db
+import database.access_channels_db as channels_db
 
 
 class Admin(commands.Cog):
@@ -22,6 +24,15 @@ class Admin(commands.Cog):
 
     # AIR
     # ORION
+
+    @commands.command("rme", hidden=True)
+    async def rme(self, ctx, arg):
+        """ Remove an entry from db by id """
+        if ctx.author.id != OWNER_ID:
+            return
+        channels_db.del_channel(int(arg))
+        settings_db.del_setting_by_value(ctx.guild.id, int(arg))
+        await ctx.send("Done")
 
     # ROLE ID
     @commands.command(name="role-id", aliases=["roleid", "rid", "r-id"],

--- a/src/cogs/on_voice_update.py
+++ b/src/cogs/on_voice_update.py
@@ -169,6 +169,7 @@ def generate_text_channel_overwrite(
     Gives read/ write permission to:\n
     - roles that are registered as allowed in the settings
     - members that are currently in the voice channel
+    - the bot member creating that channel
 
     Prohibits guilds default role from accessing the channel
 

--- a/src/cogs/on_voice_update.py
+++ b/src/cogs/on_voice_update.py
@@ -254,11 +254,11 @@ class VCCreator(commands.Cog):
             created_channel: Union[db.CreatedChannels, None] = channels_db.get_voice_channel_by_id(after_channel.id)
 
             # check if joined (after) channel is a channel that triggers a channel creation
-            create_channel = settings_db.get_setting_by_value(guild.id, after_channel.id)
+            tracked_channel = settings_db.get_setting_by_value(guild.id, after_channel.id)
 
-            if create_channel:
+            if tracked_channel:
                 voice_channel, text_channel = await create_new_channels(member, after,
-                                                                        create_channel.setting, bot_member_on_guild)
+                                                                        tracked_channel.setting, bot_member_on_guild)
 
                 # write to log channel if configured
                 if log_entry:

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -164,6 +164,7 @@ class Settings(commands.Cog):
         # get channel setting or setting string
         setting_setting = settings.get(value, None)  # name of setting
         value_setting = utils.extract_id_from_message(value)  # id / value of setting
+
         if not (setting_setting or value_setting):
             emby = utils.make_embed(color=utils.orange,
                                     name="No valid setting",
@@ -177,7 +178,11 @@ class Settings(commands.Cog):
             settings_db.del_setting_by_setting(ctx.guild.id, setting_setting)
 
         elif value_setting:
-            settings_db.del_setting_by_value(ctx.guild.id, str(value_setting))
+            # We don't know if the setting we aim for is located in channels-db (like static channel)
+            # or in settings db like everything else, but that's okay, we just delete the setting in bot DBs
+            channels_db.del_channel(value_setting)                              # here if it's a static channel
+            settings_db.del_setting_by_value(ctx.guild.id, str(value_setting))  # here if it's something else
+            # TODO: If a static channel is in use when deleted from db the text-channel will stay, how to fix this?
 
         # channel only applied to setting by value
         channel = ctx.guild.get_channel(value_setting)

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -85,6 +85,7 @@ class Settings(commands.Cog):
             if entries:
                 tracked_channels.extend(entries)
 
+        stc = "__Static Channels:__\n"  # TODO: Implement static channels in settings - extra db access + loop needed
         pub = "__Public Channels:__\n"
         priv = "__Private Channels:___\n"
         log = "__Log Channel:__\n"
@@ -93,7 +94,8 @@ class Settings(commands.Cog):
         if not tracked_channels:
             emb = utils.make_embed(color=utils.yellow, name="No configuration yet",
                                    value="You didn't configure anything yet.\n"
-                                         "Use the help command or try the quick-setup to get started :)")
+                                         f"Use the help command "
+                                         f"or try the quick-setup command `{PREFIX}setup @role` to get started :)")
             await ctx.send(embed=emb)
             return
 
@@ -123,6 +125,7 @@ class Settings(commands.Cog):
 
         emby = utils.make_embed(color=utils.blue_light, name="Server Settings",
                                 value=f"‌\n"
+                                      f"{stc}\n"
                                       f"{pub}\n"
                                       f"{priv}\n"
                                       f"{archive}\n"

--- a/src/cogs/set_settings.py
+++ b/src/cogs/set_settings.py
@@ -33,6 +33,11 @@ settings = {
     "priv": "private_channel",
     "private": "private_channel",
 
+    "stat-channel": "static_channel",
+    "static-channel": "static_channel",
+    "stat": "static_channel",
+    "static": "static_channel",
+
     "allow-edit": "allow_public_rename",
     "ae": "allow_public_rename",
     "edit": "allow_public_rename"
@@ -219,7 +224,9 @@ class Settings(commands.Cog):
         elif type(set_channel) == discord.CategoryChannel and channel_type == "archive_category":
             return str(set_channel.id), set_channel.name
 
-        elif type(set_channel) == discord.VoiceChannel and channel_type in ['public_channel', 'private_channel']:
+        elif type(set_channel) == discord.VoiceChannel and channel_type in ['public_channel',
+                                                                            'private_channel',
+                                                                            'static_channel']:
 
             # check if max for tracked channels is reached
             if not settings_db.is_track_limit_reached(ctx.guild.id, channel_type):
@@ -375,32 +382,32 @@ class Settings(commands.Cog):
         help=f"__**Configure Voice Channel behaviour**__:\n"
              f"Register a voice channel that members can join to get an own channel\n\n"
              "__Usage:__\n"
-             f"`{PREFIX}set` [_public_ | _private_] [_channel-id_]\n\n"
-             "_public_ or _private_ is the option for the channel-type that's created when joining the channel.\n\n"
-             f""
+             f"`{PREFIX}set` [_public_ | _private_ | _static_] [_channel-id_]\n\n"
+             "_public_, _private_ is the option for the channel-type that's created when joining the channel.\n"
+             "_static_ symbolizes that only a linked text-channel shall be created on join.\n\n"
              f"__**Other  settings:**__\n\n"
              f"__log:__\n"
-             f"Channel for log messages\n"
+             f"Channel for log\n"
              f"__archive:__\n"
-             f"Category linked text channels shall be moved to after linked voice-channel was deleted.\n\n"
+             f"Category text channels shall be moved to after voice-channel was deleted.\n\n"
              f"__prefix:__\n"
              f"Prefix the bot listens to on your server.\n\n"
-             "Usage\n:"
+             "Usage:\n"
              f"`{PREFIX}set` [_archive_ | _log_] [_channel-id_]\n\n"
              f"`{PREFIX}set` [_prefix_] [_new-prefix_]\n\n"
-             "Note that text-channels will only be archived when they contain at least one message, "
+             "Note that text-channels will only be archived when they contain messages, "
              "they'll be deleted otherwise.\n\n"
              f"__**Allow creator to edit the name of a public channel**__"
              f'`{PREFIX}`set [allow-edit | ae] [_yes_ | _no_]\n'
              f'This will only apply to public channels! - Private ones can always be edited.\n'
              f'Default is _no_\n\n'
-             "Your setting will be updated if you already set it earlier.\n\n"
-             f"Aliases: `add`, `svc`, `sa`, `sl`\n\n"
-             "This option is admin only")
+             "Your setting will be updated if you set it before.\n\n"
+             f"Aliases: `add`, `svc`, `sa`, `sl`\n\n")
     @commands.has_permissions(administrator=True)
     async def set_setting(self, ctx: commands.Context, *params):
         # first param setting name, second param setting value
         syntax = "Example: `set [setting name] [setting value]`"
+
         try:
             setting = params[0]
 
@@ -457,6 +464,42 @@ class Settings(commands.Cog):
             await self.update_value_or_create_entry(ctx, setting_type, set_value, set_name)
             return  # we're done - the other handling isn't needed
 
+        # handle the addition of static channels
+        # those are voice channels that are persistent but receive a new text channel every time a member joins
+        if setting_type in ['static_channel']:
+            # trying to get a corresponding channel (id: str, name/ mention: str)
+            set_value, set_name = await self.channel_from_input(ctx, setting_type, value)
+
+            # given channel id seems flawed - returning
+            if not set_value:
+                return
+
+            channel: discord.VoiceChannel = await self.validate_channel(ctx, set_value)
+
+            if channel is None:
+                return
+
+            session = db_models.open_session()
+            entry: Union[db_models.CreatedChannels, None] = channels_db.get_voice_channel_by_id(set_value, session)
+
+            if entry:
+                entry.internal_type = setting_type
+                session.add(entry)
+                session.commit()
+                await self.send_setting_updated(ctx, setting_type, set_name)
+                return
+
+            # delete old setting if channels was e.g. public-channel before
+            settings_db.del_setting_by_value(ctx.guild.id, set_value)
+            channels_db.add_channel(voice_channel_id=int(set_value),
+                                    text_channel_id=None,
+                                    guild_id=ctx.guild.id,
+                                    internal_type=setting_type,
+                                    category=channel.category_id,
+                                    set_by=ctx.author.id)
+
+            await self.send_setting_added(ctx, setting_type, set_name)
+
         # now handle tracked channels
         # tracked channels require an other database handling as the other settings
         # we need to check if there is a setting with that value and adjust the setting_name
@@ -486,6 +529,10 @@ class Settings(commands.Cog):
 
             # create new entry, channel not tracked yet
             else:
+
+                # delete old entry in channels db if it exists - maybe channel was static channel before
+                channels_db.del_channel(int(set_value))
+
                 # write entry to db
                 settings_db.add_setting(
                     guild_id=ctx.guild.id,

--- a/src/database/db_models.py
+++ b/src/database/db_models.py
@@ -47,7 +47,10 @@ class Settings(Base):
     __tablename__ = 'SETTINGS'
 
     # setting names:
-    # mod_role, public_channel, private_channel, archive_category, log_channel, allow_public_rename, prefix
+    # public_channel, private_channel,
+    # static_channel (won't be deleted when empty),
+    # archive_category, log_channel,
+    # mod_role, allow_public_rename, prefix
 
     id = Column(Integer, primary_key=True)
     guild_id = Column(BigInteger)      # ID of guild setting is applied to


### PR DESCRIPTION
### main feature
This PR implements dynamically created private text-channels for channels that are static - means that they were not created dynamically by the bot and shall not be removed when empty. Something like the 'General' VC.  

This setting needs a new internal type of channel after 'public' and 'private' 'static' is added.  

The options to add and remove a static channel are implemented in the central `set` / `delete-setting` command.  

Handling the creation and removal / archiving of those linked text-channels is integrated in the main listener/ function for handling bot created channels.

As I briefly mentioned above: a new text-channel will be created as soon as the first member joins the channel.  
When the channel is empty again this text-channel will be treated as a normal linked text-channel (deleted/ archived).  
And a new text-channel will be created when a user joins again.  
The new channel will have the same name as the static voice channel.

### other additions
A welcome message will be sent into created text-channels to explain the sense and usage of that channel.  

#### note
The display-settings command does not show static channels at the moment.  
Plus there is a bug where the linked text-channel won't be removed when the setting was deleted while the channel was in use.  